### PR TITLE
Ensure foot placements persist across rows for parity counts

### DIFF
--- a/src/step_parity.rs
+++ b/src/step_parity.rs
@@ -275,13 +275,15 @@ impl Row {
         }
         self.note_count = 0;
         for c in 0..self.column_count {
+            let foot = foot_placement[c];
+            self.columns[c] = foot;
+
+            if foot != Foot::None {
+                self.where_the_feet_are[foot.as_index()] = c as isize;
+            }
+
             if self.notes[c].note_type != TapNoteType::Empty {
-                let foot = foot_placement[c];
                 self.notes[c].parity = foot;
-                self.columns[c] = foot;
-                if foot != Foot::None {
-                    self.where_the_feet_are[foot.as_index()] = c as isize;
-                }
                 self.note_count += 1;
             }
         }


### PR DESCRIPTION
## Summary
- keep each row's foot placements populated with the final combined state so ongoing holds retain their assigned foot
- allow downstream crossover, sideswitch, jack, and bracket detection to match StepMania's parity counts

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f5f8a315988329acc76f74e25ba615