### PR TITLE
fix: Normalize speeds using the correct format

### DIFF
--- a/crates/rssp-core/src/bpm.rs
+++ b/crates/rssp-core/src/bpm.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::str::Split;
 
 use crate::math::{fmt_dec3_half_up, push_dec3_half_up, round_sig_figs_itg, roundtrip_bpm_itg};
 use crate::parse::{
@@ -75,6 +76,43 @@ pub fn normalize_float_digits(param: &str) -> String {
             push_dec3_half_up(&mut out, v);
         }
     }
+    out
+}
+
+#[must_use]
+pub fn normalize_speeds_float_digits(param: &str) -> String {
+    let mut out = String::with_capacity(param.len());
+    for entry in param.split(',') {
+        let t = entry.trim();
+        if t.is_empty() {
+            continue;
+        }
+        let mut split = t.split('=');
+        match (split.next(), split.next(), split.next(), split.next()) {
+            (Some(b), Some(r), Some(d), Some(u)) => {
+                if let (Some(beat), Some(ratio), Some(delay)) = (
+                    parse_normalized_decimal(b),
+                    parse_normalized_decimal(r),
+                    parse_normalized_decimal(d),
+                ) {
+                    if !out.is_empty() {
+                        out.push(',');
+                    }
+                    push_dec3_half_up(&mut out, beat);
+                    out.push('=');
+                    push_dec3_half_up(&mut out, ratio);
+                    out.push('=');
+                    push_dec3_half_up(&mut out, delay);
+                    out.push('=');
+                    out += u;
+                }
+            }
+            _ => {
+                // Not enough values to parse - skip this row
+            }
+        }
+    }
+
     out
 }
 

--- a/crates/rssp-core/src/bpm.rs
+++ b/crates/rssp-core/src/bpm.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::str::Split;
 
 use crate::math::{fmt_dec3_half_up, push_dec3_half_up, round_sig_figs_itg, roundtrip_bpm_itg};
 use crate::parse::{

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Instant;
 
+use rssp_core::bpm::normalize_speeds_float_digits;
+
 use crate::duration::{self, TimingOffsets};
 use crate::report::{ChartSummary, SimfileSummary};
 use crate::stats;
@@ -991,7 +993,7 @@ pub fn analyze(
         .speeds
         .and_then(|b| std::str::from_utf8(b).ok())
         .unwrap_or("");
-    let normalized_global_speeds = normalize_float_digits(global_speeds_raw);
+    let normalized_global_speeds = normalize_speeds_float_digits(global_speeds_raw);
     let cleaned_global_speeds = clean_timing_map(global_speeds_raw);
     let global_scrolls_raw = parsed_data
         .scrolls

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -2,8 +2,6 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Instant;
 
-use rssp_core::bpm::normalize_speeds_float_digits;
-
 use crate::duration::{self, TimingOffsets};
 use crate::report::{ChartSummary, SimfileSummary};
 use crate::stats;
@@ -12,6 +10,7 @@ use crate::step_parity;
 use crate::bpm::{
     clean_timing_map, clean_timing_map_cow, compute_bpm_range, compute_bpm_stats,
     compute_measure_nps_vec_with_timing, compute_tier_bpm, get_nps_stats, normalize_float_digits,
+    normalize_speeds_float_digits,
 };
 use crate::hash::{compute_chart_hash, compute_chart_hash_pair};
 use crate::math::{round_dp, round_sig_figs_6};


### PR DESCRIPTION
Previously, `normalized_speeds` used the helper function `normalize_float_digits`, which parses two `=`-separated numbers as floats. However, the `SPEEDS` tag uses a different `float=float=float=int` row format, so this call of `normalize_float_digits` ended up skipping every (valid) speed row. Consequently, `SimfileSummary.normalized_speeds` was typically an empty string, even for songs containing speed changes.

This bug didn't affect song timing in DeadSync because the timing data is cleaned separately (see  `cleaned_global_speeds` below the changed line in `analysis.rs`). However, it did affect simfile serialization (a forthcoming PR).

To fix this, I added a variant of the helper function that handles the `SPEEDS` format, following the logic in ITGmania's [notes loader](https://github.com/itgmania/itgmania/blob/8a3bf8884acdcb69363f7f0ea592138e398c71e4/src/NotesLoaderSM.cpp#L825) (e.g. dropping rows with too few values and ignoring any extra values).