### PR TITLE
Implement simfile serialization and `.sm` warp hack converter

### DIFF
--- a/crates/rssp-core/src/timing.rs
+++ b/crates/rssp-core/src/timing.rs
@@ -1,6 +1,7 @@
 use crate::bpm::{clean_timing_map_cow, parse_beat_or_row, parse_bpm_map};
 use crate::math::{lrint_f32, lrint_f64, push_dec6_itg, roundtrip_bpm_itg};
 use crate::parse::parse_offset_seconds;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 
 // --- Constants ---
@@ -1049,6 +1050,81 @@ fn process_bpms_and_stops_sm(
     sort_segments_by_beat(&mut out_warps);
 
     (out_bpms, out_stops, out_warps, f64::from(beat0_offset))
+}
+
+pub fn convert_warps_and_delays_to_sm_stops<'a>(
+    bpms: &[(f32, f32)],
+    stops: &'a [(f32, f32)],
+    delays: &[(f32, f32)],
+    warps: &[(f32, f32)],
+) -> Cow<'a, [(f32, f32)]> {
+    if delays.is_empty() && warps.is_empty() {
+        return Cow::Borrowed(stops);
+    }
+
+    let mut warp_stops = Vec::new();
+    let mut bpm_index = 0;
+    for (warp_beat, warp_value) in warps {
+        // Find the current BPM
+        while bpm_index + 1 < bpms.len() && bpms[bpm_index + 1].0 <= *warp_beat {
+            bpm_index += 1;
+        }
+        let bps = 60.0 / bpms[bpm_index].1;
+        let skip = bps * warp_value;
+        warp_stops.push((*warp_beat, -skip));
+    }
+
+    // Perform a 3-way merge on the SM stop sources.
+    // If two sources apply the same beat, sum up their values into a single pair.
+    let mut sm_stops = Vec::with_capacity(stops.len() + delays.len() + warp_stops.len());
+    let mut stops_index = 0;
+    let mut delays_index = 0;
+    let mut warp_stops_index = 0;
+
+    while stops_index < stops.len()
+        || delays_index < delays.len()
+        || warp_stops_index < warp_stops.len()
+    {
+        // Find the smallest remaining key.
+        let mut key = None;
+
+        if stops_index < stops.len() {
+            key = Some(stops[stops_index].0);
+        }
+        if delays_index < delays.len() && key.is_none_or(|k| delays[delays_index].0 < k) {
+            key = Some(delays[delays_index].0);
+        }
+        if warp_stops_index < warp_stops.len()
+            && key.is_none_or(|k| warp_stops[warp_stops_index].0 < k)
+        {
+            key = Some(warp_stops[warp_stops_index].0);
+        }
+
+        let key = match key {
+            Some(k) => k,
+            None => break, // Should be unreachable, but just in case
+        };
+        let mut value = 0.0;
+
+        if stops_index < stops.len() && stops[stops_index].0 == key {
+            value += stops[stops_index].1;
+            stops_index += 1;
+        }
+        if delays_index < delays.len() && delays[delays_index].0 == key {
+            value += delays[delays_index].1;
+            delays_index += 1;
+        }
+        if warp_stops_index < warp_stops.len() && warp_stops[warp_stops_index].0 == key {
+            value += warp_stops[warp_stops_index].1;
+            warp_stops_index += 1;
+        }
+
+        if value != 0.0 {
+            sm_stops.push((key, value));
+        }
+    }
+
+    Cow::Owned(sm_stops)
 }
 
 // --- TimingData ---

--- a/crates/rssp/Cargo.toml
+++ b/crates/rssp/Cargo.toml
@@ -25,6 +25,7 @@ libtest-mimic = "0.8.1"
 zstd = "0.13.3"
 criterion = "0.8.1"
 pretty_assertions = "1.4.1"
+ctrlc = "3.5.2"
 
 [[test]]
 name = "hash_parity"
@@ -89,6 +90,11 @@ harness = false
 [[test]]
 name = "fast_all_parity"
 path = "tests/fast_all_parity.rs"
+harness = false
+
+[[test]]
+name = "serialize_parity"
+path = "tests/serialize_parity.rs"
 harness = false
 
 [[bench]]

--- a/crates/rssp/Cargo.toml
+++ b/crates/rssp/Cargo.toml
@@ -24,6 +24,7 @@ md5 = "0.8.0"
 libtest-mimic = "0.8.1"
 zstd = "0.13.3"
 criterion = "0.8.1"
+pretty_assertions = "1.4.1"
 
 [[test]]
 name = "hash_parity"

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -1465,6 +1465,7 @@ mod tests {
         } else {
             description.clone()
         };
+        let chart_style = String::new();
 
         ChartMetadataStrings {
             step_type,

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -1026,14 +1026,6 @@ pub fn analyze(
         .credit
         .map(decode_unescape_owned)
         .unwrap_or_default();
-    let origin_str = parsed_data
-        .origin
-        .map(|b| unescape_tag(decode_bytes(b).as_ref()).into_owned())
-        .unwrap_or_default();
-    let credit_str = parsed_data
-        .credit
-        .map(|b| unescape_tag(decode_bytes(b).as_ref()).into_owned())
-        .unwrap_or_default();
     let banner_path_str = parsed_data
         .banner
         .map(decode_unescape_owned)

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -1026,6 +1026,14 @@ pub fn analyze(
         .credit
         .map(decode_unescape_owned)
         .unwrap_or_default();
+    let origin_str = parsed_data
+        .origin
+        .map(|b| unescape_tag(decode_bytes(b).as_ref()).into_owned())
+        .unwrap_or_default();
+    let credit_str = parsed_data
+        .credit
+        .map(|b| unescape_tag(decode_bytes(b).as_ref()).into_owned())
+        .unwrap_or_default();
     let banner_path_str = parsed_data
         .banner
         .map(decode_unescape_owned)

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -1465,7 +1465,6 @@ mod tests {
         } else {
             description.clone()
         };
-        let chart_style = String::new();
 
         ChartMetadataStrings {
             step_type,

--- a/crates/rssp/src/lib.rs
+++ b/crates/rssp/src/lib.rs
@@ -3,6 +3,7 @@ pub mod assets;
 pub mod course;
 pub mod pack;
 pub mod report;
+pub mod serialize;
 pub mod simfile;
 pub mod translate;
 

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -426,7 +426,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::StrNoEscapeOpt(chart.chart_scrolls.as_deref())),
         Prop::own_timing_only(b"FAKES", PropValue::StrNoEscapeOpt(chart.chart_fakes.as_deref())),
         Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::StrNoEscapeOpt(chart.chart_labels.as_deref())),
-        Prop::nonempty_only(b"ATTACKS", PropValue::StrNoEscapeOpt(chart.chart_attacks.as_deref())),
+        Prop::nonempty_only(b"ATTACKS", PropValue::StrNoEscapeOpt(chart.chart_has_own_attacks.then(|| chart.chart_attacks.as_deref()).flatten())),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscapeOpt(chart.chart_display_bpm.as_deref())),
         Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
         Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -81,31 +81,29 @@ enum PropValue<'a> {
 impl<'a> PropValue<'a> {
     #[must_use]
     fn serialize(&self, out: &mut dyn io::Write) -> io::Result<usize> {
-        use PropValue::*;
-
         match self {
-            Empty => Ok(0),
-            Str(s) => sm_escape(out, s.as_bytes()),
-            StrOpt(opt) => match opt {
+            PropValue::Empty => Ok(0),
+            PropValue::Str(s) => sm_escape(out, s.as_bytes()),
+            PropValue::StrOpt(opt) => match opt {
                 None => Ok(0),
-                Some(s) => Str(s).serialize(out),
+                Some(s) => PropValue::Str(s).serialize(out),
             },
-            Bytes(b) => write_all!(out, b),
-            NoteData(b) => Ok(write_all!(out, b"\n")? + write_all!(out, b)?),
-            Version(v) => write_all!(out, format_version(*v).as_bytes()),
-            Number(n) => write_all!(out, format_dot6_f64(*n).as_bytes()),
-            NumberOpt(opt) => match opt {
+            PropValue::Bytes(b) => write_all!(out, b),
+            PropValue::NoteData(b) => Ok(write_all!(out, b"\n")? + write_all!(out, b)?),
+            PropValue::Version(v) => write_all!(out, format_version(*v).as_bytes()),
+            PropValue::Number(n) => write_all!(out, format_dot6_f64(*n).as_bytes()),
+            PropValue::NumberOpt(opt) => match opt {
                 None => Ok(0),
-                Some(n) => Number(*n).serialize(out),
+                Some(n) => PropValue::Number(*n).serialize(out),
             },
-            Bool(b) => {
+            PropValue::Bool(b) => {
                 if *b {
                     write_all!(out, b"YES")
                 } else {
                     write_all!(out, b"NO")
                 }
             }
-            NormalizedList(items_str) => {
+            PropValue::NormalizedList(items_str) => {
                 let items = items_str.as_bytes();
                 let mut written_bytes = 0;
                 let mut start = 0;
@@ -120,11 +118,11 @@ impl<'a> PropValue<'a> {
                 written_bytes += write_all!(out, &items[start..])?;
                 Ok(written_bytes)
             }
-            NormalizedListOpt(opt_items_str) => match opt_items_str {
+            PropValue::NormalizedListOpt(opt_items_str) => match opt_items_str {
                 None => Ok(0),
-                Some(items_str) => NormalizedList(items_str).serialize(out),
+                Some(items_str) => PropValue::NormalizedList(items_str).serialize(out),
             },
-            RadarValues(rv) => match rv {
+            PropValue::RadarValues(rv) => match rv {
                 Some(values) => {
                     let mut written_bytes = 0;
                     let mut first_item = true;
@@ -146,20 +144,19 @@ impl<'a> PropValue<'a> {
 
     #[must_use]
     fn is_empty(&self) -> bool {
-        use PropValue::*;
         match self {
-            Empty => true,
-            Str(s) => s.is_empty(),
-            StrOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
-            Bytes(b) => b.is_empty(),
-            NoteData(_) => false,
-            Version(_) => false,
-            Number(_) => false,
-            NumberOpt(opt) => opt.is_none(),
-            Bool(_) => false,
-            NormalizedList(s) => s.is_empty(),
-            NormalizedListOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
-            RadarValues(rv) => rv.is_none(),
+            PropValue::Empty => true,
+            PropValue::Str(s) => s.is_empty(),
+            PropValue::StrOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
+            PropValue::Bytes(b) => b.is_empty(),
+            PropValue::NoteData(_) => false,
+            PropValue::Version(_) => false,
+            PropValue::Number(_) => false,
+            PropValue::NumberOpt(opt) => opt.is_none(),
+            PropValue::Bool(_) => false,
+            PropValue::NormalizedList(s) => s.is_empty(),
+            PropValue::NormalizedListOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
+            PropValue::RadarValues(rv) => rv.is_none(),
         }
     }
 }
@@ -395,7 +392,7 @@ fn serialize_sm_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> i
     written_bytes += write_all!(out, b"#NOTES:\n")?;
 
     // Kludge: don't use `Prop#serialize` here because SM charts are special.
-    // We use `Prop` anyway for the sake of `new_with_default`.
+    // We use `Prop` anyway for the convenience of `new_with_default` and `PropValue::RadarValues`.
     #[rustfmt::skip]
     let props = [
         Prop::new_with_default(b"", DEFAULT_STEPSTYPE, PropValue::Str(&chart.step_type_str)),
@@ -433,7 +430,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::new(b"CHARTSTYLE", PropValue::Str(&chart.chart_style_str)),
         Prop::new_with_default(b"DIFFICULTY", DEFAULT_DIFFICULTY, PropValue::Str(&chart.difficulty_str)),
         Prop::new_with_default(b"METER", DEFAULT_METER, PropValue::Str(&chart.rating_str)),
-        Prop::nonempty_only(b"MUSIC", PropValue::Str(&chart.music_path)), // TODO
+        Prop::nonempty_only(b"MUSIC", PropValue::Str(&chart.music_path)),
         Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values)),
         Prop::new(b"CREDIT", PropValue::Str(&chart.step_artist_str)),
         Prop::own_timing_only(b"OFFSET", PropValue::Number(chart.chart_offset_seconds)),

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -509,7 +509,7 @@ mod tests {
             4.500=4.750;\n\
             #LABELS:0.000=Song Start,\n\
             16.000=Speedup;\n\
-            #BGCHANGES:;\n\
+            #BGCHANGES:BGChanges;\n\
             #KEYSOUNDS:;\n\
             #ATTACKS:;\n\
             \n\
@@ -520,7 +520,8 @@ mod tests {
             #CHARTSTYLE:Chart style;\n\
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
-            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
+            0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #NOTES:\n\
             0000\n\
@@ -536,7 +537,8 @@ mod tests {
             #CHARTSTYLE:Chart style;\n\
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
-            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
+            0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
             #BPMS:0.000=120.000,\n\
@@ -650,10 +652,10 @@ mod tests {
             #LABELS:0.000=Song Start,\n\
             16.000=Speedup;\n\
             #LASTSECONDHINT:120.000000;\n\
-            #BGCHANGES:;\n\
-            #FGCHANGES:;\n\
+            #BGCHANGES:BGChanges;\n\
+            #FGCHANGES:FGChanges;\n\
             #KEYSOUNDS:;\n\
-            #ATTACKS:;\n\
+            #ATTACKS:Attacks;\n\
             \n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
@@ -663,9 +665,10 @@ mod tests {
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
             #MUSIC:chart_music.ogg;\n\
-            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
+            0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
-            #ATTACKS:;\n\
+            #ATTACKS:Attacks;\n\
             #DISPLAYBPM:300;\n\
             #NOTES:\n\
             0000\n\
@@ -682,7 +685,8 @@ mod tests {
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
             #MUSIC:chart_music.ogg;\n\
-            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
+            0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
             #BPMS:0.000=120.000,\n\
@@ -713,7 +717,7 @@ mod tests {
             4.500=4.750;\n\
             #LABELS:0.000=Song Start,\n\
             16.000=Speedup;\n\
-            #ATTACKS:;\n\
+            #ATTACKS:Attacks;\n\
             #DISPLAYBPM:300;\n\
             #NOTES:\n\
             0000\n\
@@ -783,7 +787,7 @@ mod tests {
             #FAKES:4.000=4.250,\n\
             4.500=4.750;\n\
             #LABELS:0.000000=Song Start;\n\
-            #BGCHANGES:;\n\
+            #BGCHANGES:BGChanges;\n\
             #KEYSOUNDS:;\n\
             #ATTACKS:;\n\
             \n\
@@ -794,7 +798,8 @@ mod tests {
             #CHARTSTYLE:Chart style;\n\
             #DIFFICULTY:Beginner;\n\
             #METER:1;\n\
-            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
+            0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #NOTES:\n\
             0000\n\
@@ -810,7 +815,8 @@ mod tests {
             #CHARTSTYLE:Chart style;\n\
             #DIFFICULTY:Beginner;\n\
             #METER:1;\n\
-            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
+            0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
             #BPMS:0.000000=60.000000;\n\
@@ -878,11 +884,11 @@ mod tests {
         48.000=120.000;\n\
         #STOPS:1.000=1.250,\n\
         1.500=1.750;\n\
-        #BGCHANGES:;\n\
+        #BGCHANGES:BGChanges;\n\
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
         \n\
-        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
         0000\n\
         0000\n\
         0000\n\
@@ -933,12 +939,12 @@ mod tests {
         48.000=120.000;\n\
         #STOPS:1.000=1.250,\n\
         1.500=1.750;\n\
-        #BGCHANGES:;\n\
-        #FGCHANGES:;\n\
+        #BGCHANGES:BGChanges;\n\
+        #FGCHANGES:FGChanges;\n\
         #KEYSOUNDS:;\n\
-        #ATTACKS:;\n\
+        #ATTACKS:Attacks;\n\
         \n\
-        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
         0000\n\
         0000\n\
         0000\n\
@@ -986,11 +992,11 @@ mod tests {
         #BPMS:0.000000=60.000000;\n\
         #STOPS:1.000=1.250,\n\
         1.500=1.750;\n\
-        #BGCHANGES:;\n\
+        #BGCHANGES:BGChanges;\n\
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
         \n\
-        #NOTES:\n     dance-single:\n     Description:\n     Beginner:\n     1:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        #NOTES:\n     dance-single:\n     Description:\n     Beginner:\n     1:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
         0000\n\
         0000\n\
         0000\n\
@@ -1092,14 +1098,18 @@ mod tests {
             sample_length: 16.0,
             origin_str: String::from("Origin"),
             credit_str: String::from("Credit"),
-            normalized_bgchanges: Default::default(), // TODO
+            normalized_bgchanges: String::from("BGChanges"), // TODO: replace with valid string
             normalized_fgchanges: if include_nonempty {
-                Default::default() // TODO
+                String::from("FGChanges") // TODO: replace with valid string
             } else {
                 Default::default()
             },
             normalized_keysounds: Default::default(), // TODO
-            normalized_attacks: Default::default(),   // TODO
+            normalized_attacks: if include_nonempty {
+                String::from("Attacks") // TODO: replace with valid string
+            } else {
+                Default::default()
+            },
             previewvid_path: String::from("previewvid.mov"),
             cdimage_path: String::from("cdimage.png"),
             discimage_path: String::from("discimage.png"),
@@ -1176,7 +1186,7 @@ mod tests {
                 .then(|| String::from("0.000=4,16.000=2,48.000=4")),
             chart_combos: (has_own_timing && !trigger_defaults)
                 .then(|| String::from("0.000=1,16.000=2,48.000=1")),
-            chart_attacks: include_nonempty.then(|| Default::default()), // TODO
+            chart_attacks: include_nonempty.then(|| String::from("Attacks")), // TODO
             chart_display_bpm: include_nonempty.then(|| String::from("300")),
 
             // These are currently unused in favor of the `chart_*` fields above

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -9,182 +9,615 @@ const DEFAULT_TIME_SIGNATURES: &str = "0.000000=4=4";
 const DEFAULT_SPEEDS: &str = "0.000000=1.000000=0.000000=0";
 const DEFAULT_SCROLLS: &str = "0.000000=1.000000";
 
-fn serialize_prop(key: &[u8], value: &[u8], out: &mut dyn io::Write) -> Result<usize, io::Error> {
-    let written_bytes = out.write(b"#")?
-        + out.write(key)?
-        + out.write(b":")?
-        + out.write(value)?
-        + out.write(b";\n")?;
+enum ValueWriter {
+    Plain,
+    List,
+}
+
+macro_rules! write_all {
+    ($out:expr, $value:expr) => {
+        $out.write_all($value).map(|_| $value.len())
+    };
+}
+
+fn write_prop(
+    key: &[u8],
+    value: &[u8],
+    writer: ValueWriter,
+    out: &mut dyn io::Write,
+) -> Result<usize, io::Error> {
+    let mut written_bytes = 0;
+    written_bytes += write_all!(out, b"#")?;
+    written_bytes += write_all!(out, key)?;
+    written_bytes += write_all!(out, b":")?;
+    written_bytes += match writer {
+        ValueWriter::Plain => write_all!(out, value)?,
+        ValueWriter::List => write_comma_separated_list(out, value)?,
+    };
+    written_bytes += write_all!(out, b";\n")?;
     Ok(written_bytes)
 }
 
-fn serialize_sm_chart_field(value: &str, out: &mut dyn io::Write) -> Result<usize, io::Error> {
-    let written_bytes = out.write(b"     ")? + out.write(value.as_bytes())? + out.write(b":\n")?;
+fn write_comma_separated_list(out: &mut dyn io::Write, value: &[u8]) -> io::Result<usize> {
+    let mut written_bytes = 0;
+    let mut start = 0;
+
+    while let Some(offset) = value[start..].iter().position(|&b| b == b',') {
+        let comma = start + offset;
+        written_bytes += write_all!(out, &value[start..=comma])?;
+        written_bytes += write_all!(out, b"\n")?;
+        start = comma + 1;
+    }
+
+    written_bytes += write_all!(out, &value[start..])?;
     Ok(written_bytes)
 }
 
+fn write_sm_chart_field(value: &str, out: &mut dyn io::Write) -> Result<usize, io::Error> {
+    let written_bytes =
+        write_all!(out, b"     ")? + out.write(value.as_bytes())? + write_all!(out, b":\n")?;
+    Ok(written_bytes)
+}
+
+#[inline(always)]
 fn format_version(ssc_version: f32) -> String {
     format!("{:.2}", ssc_version)
 }
 
-fn format_f64(value: f64) -> String {
+#[inline(always)]
+fn format_dot6_f64(value: f64) -> String {
     format!("{:.6}", value)
 }
 
-fn format_f32(value: f32) -> String {
-    format!("{:.3}", value)
+#[inline(always)]
+fn format_dot6_f32(value: f32) -> String {
+    format!("{:.6}", value)
 }
 
 fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
     match radar_values {
         Some(radar_values) => radar_values
             .iter()
-            .map(|&f| format_f32(f))
+            .map(|&f| format_dot6_f32(f))
             .collect::<Vec<String>>()
-            .join(":"),
+            .join(","),
         None => String::from(""),
     }
 }
 
 pub fn serialize_simfile(
-    summary: SimfileSummary,
+    summary: &SimfileSummary,
     extension: &str,
     out: &mut dyn io::Write,
 ) -> io::Result<usize> {
+    use ValueWriter::*;
+
     let ssc = extension_is_ssc(extension)?;
 
     let mut written_bytes = 0;
 
-    {
-        let properties: Vec<(&[u8], String, bool)> = vec![
-            (b"VERSION", format_version(summary.ssc_version), ssc),
-            (b"TITLE", summary.title_str, true),
-            (b"SUBTITLE", summary.subtitle_str, true),
-            (b"ARTIST", summary.artist_str, true),
-            (b"TITLETRANSLIT", summary.titletranslit_str, true),
-            (b"SUBTITLETRANSLIT", summary.subtitletranslit_str, true),
-            (b"ARTISTTRANSLIT", summary.artisttranslit_str, true),
-            (b"GENRE", summary.genre_str, true),
-            (b"OFFSET", format_f64(summary.offset), true),
-            // TODO: store attacks on SimfileSummary
-            (b"ATTACKS", String::from(""), true),
-            (b"BPMS", summary.normalized_bpms, true),
-            (b"STOPS", summary.normalized_stops, true),
-            (b"DELAYS", summary.normalized_delays, true),
-            (b"TIMESIGNATURES", summary.normalized_time_signatures, true),
-            (b"TICKCOUNTS", summary.normalized_tickcounts, true),
-            (b"BANNER", summary.banner_path, true),
-            (b"BACKGROUND", summary.background_path, true),
-            (b"CDTITLE", summary.cdtitle_path, true),
-            (b"JACKET", summary.jacket_path, true),
-            (b"MUSIC", summary.music_path, true),
-            (b"SAMPLESTART", format_f64(summary.sample_start), true),
-            (b"SAMPLELENGTH", format_f64(summary.sample_length), true),
-            (b"DISPLAYBPM", summary.display_bpm_str, true),
-            (b"FAKES", summary.normalized_fakes, ssc),
-            (b"WARPS", summary.normalized_warps, ssc),
-            (b"SPEEDS", summary.normalized_speeds, ssc),
-            (b"SCROLLS", summary.normalized_scrolls, ssc),
-            (b"LABELS", summary.normalized_labels, ssc),
-            (b"COMBOS", summary.normalized_combos, ssc),
-        ];
+    let formatted_version = format_version(summary.ssc_version);
+    let formatted_offset = format_dot6_f64(summary.offset);
+    let formatted_sample_start = format_dot6_f64(summary.sample_start);
+    let formatted_sample_length = format_dot6_f64(summary.sample_length);
 
-        for property in properties {
-            if property.2 {
-                written_bytes += serialize_prop(property.0, property.1.as_bytes(), out)?;
-            }
+    // (key, value, is_included, value_writer)
+    let properties: Vec<(&[u8], &str, bool, ValueWriter)> = vec![
+        (b"VERSION", &formatted_version, ssc, Plain),
+        (b"TITLE", &summary.title_str, true, Plain),
+        (b"SUBTITLE", &summary.subtitle_str, true, Plain),
+        (b"ARTIST", &summary.artist_str, true, Plain),
+        (b"TITLETRANSLIT", &summary.titletranslit_str, true, Plain),
+        (
+            b"SUBTITLETRANSLIT",
+            &summary.subtitletranslit_str,
+            true,
+            Plain,
+        ),
+        (b"ARTISTTRANSLIT", &summary.artisttranslit_str, true, Plain),
+        (b"GENRE", &summary.genre_str, true, Plain),
+        (b"ORIGIN", "", true, Plain), // TODO
+        (b"CREDIT", "", true, Plain), // TODO
+        (b"BANNER", &summary.banner_path, true, Plain),
+        (b"BACKGROUND", &summary.background_path, true, Plain),
+        (b"PREVIEWVID", "", ssc, Plain), // TODO
+        (b"JACKET", &summary.jacket_path, ssc, Plain),
+        (b"CDIMAGE", "", ssc, Plain),     // TODO
+        (b"DISCIMAGE", "", ssc, Plain),   // TODO
+        (b"LYRICSPATH", "", true, Plain), // TODO
+        (b"CDTITLE", &summary.cdtitle_path, true, Plain),
+        (b"MUSIC", &summary.music_path, true, Plain),
+        (b"OFFSET", &formatted_offset, true, Plain),
+        (b"SAMPLESTART", &formatted_sample_start, true, Plain),
+        (b"SAMPLELENGTH", &formatted_sample_length, true, Plain),
+        (b"SELECTABLE", "YES", true, Plain), // TODO
+        (
+            b"DISPLAYBPM",
+            &summary.display_bpm_str,
+            !summary.display_bpm_str.is_empty(),
+            Plain,
+        ),
+        (b"BPMS", &summary.normalized_bpms, true, List),
+        (b"STOPS", &summary.normalized_stops, true, List),
+        (b"DELAYS", &summary.normalized_delays, ssc, List),
+        (b"WARPS", &summary.normalized_warps, ssc, List),
+        (
+            b"TIMESIGNATURES",
+            &summary.normalized_time_signatures,
+            ssc,
+            List,
+        ),
+        (b"TICKCOUNTS", &summary.normalized_tickcounts, ssc, List),
+        (b"COMBOS", &summary.normalized_combos, ssc, List),
+        (b"SPEEDS", &summary.normalized_speeds, ssc, List),
+        (b"SCROLLS", &summary.normalized_scrolls, ssc, List),
+        (b"FAKES", &summary.normalized_fakes, ssc, List),
+        (b"LABELS", &summary.normalized_labels, ssc, List),
+        (b"BGCHANGES", "", true, List), // TODO
+        (b"KEYSOUNDS", "", true, List), // TODO
+        (b"ATTACKS", "", true, List),   // TODO
+    ];
+
+    for property in properties {
+        if property.2 {
+            written_bytes += write_prop(property.0, property.1.as_bytes(), property.3, out)?;
         }
     }
 
+    written_bytes += write_all!(out, b"\n")?;
+
     match ssc {
         true => {
-            for chart in summary.charts {
-                {
-                    let chart_properties: Vec<(&[u8], String)> = vec![
-                        (b"NOTEDATA", String::from("")),
-                        (b"CHARTNAME", chart.chart_name_str),
-                        (b"STEPSTYPE", chart.step_type_str),
-                        (b"DESCRIPTION", chart.description_str),
-                        // TODO: store chart_style_str on ChartSummary
-                        (b"CHARTSTYLE", String::from("")),
-                        (b"DIFFICULTY", chart.difficulty_str),
-                        (b"METER", chart.rating_str),
-                        (
-                            b"RADARVALUES",
-                            format_radar_values(chart.cached_radar_values),
-                        ),
-                        (b"CREDIT", chart.step_artist_str),
-                    ];
-
-                    for property in chart_properties {
-                        written_bytes += serialize_prop(property.0, property.1.as_bytes(), out)?;
-                    }
-                }
-
-                if chart.chart_has_own_timing {
-                    let chart_timing_properties: Vec<(&[u8], String)> = vec![
-                        (b"OFFSET", format_f64(chart.chart_offset_seconds)),
-                        (
-                            b"BPMS",
-                            chart.chart_bpms.unwrap_or(String::from(DEFAULT_BPMS)),
-                        ),
-                        (b"STOPS", chart.chart_stops.unwrap_or(String::from(""))),
-                        (b"DELAYS", chart.chart_delays.unwrap_or(String::from(""))),
-                        (b"WARPS", chart.chart_warps.unwrap_or(String::from(""))),
-                        (
-                            b"TIMESIGNATURES",
-                            chart
-                                .chart_time_signatures
-                                .unwrap_or(String::from(DEFAULT_TIME_SIGNATURES)),
-                        ),
-                        (
-                            b"TICKCOUNTS",
-                            chart.chart_tickcounts.unwrap_or(String::from("")),
-                        ),
-                        (b"COMBOS", chart.chart_combos.unwrap_or(String::from(""))),
-                        (
-                            b"SPEEDS",
-                            chart.chart_speeds.unwrap_or(String::from(DEFAULT_SPEEDS)),
-                        ),
-                        (
-                            b"SCROLLS",
-                            chart.chart_scrolls.unwrap_or(String::from(DEFAULT_SCROLLS)),
-                        ),
-                        (b"FAKES", chart.chart_fakes.unwrap_or(String::from(""))),
-                        (b"LABELS", chart.chart_labels.unwrap_or(String::from(""))),
-                        (b"ATTACKS", chart.chart_attacks.unwrap_or(String::from(""))),
-                        (
-                            b"DISPLAYBPM",
-                            chart.chart_display_bpm.unwrap_or(String::from("")),
-                        ),
-                    ];
-
-                    for property in chart_timing_properties {
-                        written_bytes += serialize_prop(property.0, property.1.as_bytes(), out)?;
-                    }
-                }
-
-                // TODO: handle #NOTES2 correctly
-                written_bytes += out.write(b"#NOTES:\n")?;
-                written_bytes += out.write(&chart.minimized_note_data)?;
-                written_bytes += out.write(b";\n")?;
+            for chart in &summary.charts {
+                written_bytes += serialize_ssc_chart(out, chart)?;
+                written_bytes += write_all!(out, b"\n")?;
             }
         }
-        // SM
         false => {
-            for chart in summary.charts {
-                written_bytes += out.write(b"#NOTES:\n")?;
-                written_bytes += serialize_sm_chart_field(&chart.step_type_str, out)?;
-                written_bytes += serialize_sm_chart_field(&chart.description_str, out)?;
-                written_bytes += serialize_sm_chart_field(&chart.difficulty_str, out)?;
-                written_bytes += serialize_sm_chart_field(&chart.rating_str, out)?;
-                written_bytes +=
-                    serialize_sm_chart_field(&format_radar_values(chart.cached_radar_values), out)?;
-                written_bytes += out.write(&chart.minimized_note_data)?;
-                written_bytes += out.write(b";\n")?;
+            for chart in &summary.charts {
+                written_bytes += serialize_sm_chart(out, chart)?;
+                written_bytes += write_all!(out, b"\n")?;
             }
         }
     }
 
     Ok(written_bytes)
+}
+
+fn serialize_sm_chart(
+    out: &mut dyn io::Write,
+    chart: &crate::ChartSummary,
+) -> Result<usize, io::Error> {
+    let mut written_bytes = 0;
+    written_bytes += write_all!(out, b"#NOTES:\n")?;
+    written_bytes += write_sm_chart_field(&chart.step_type_str, out)?;
+    written_bytes += write_sm_chart_field(&chart.description_str, out)?;
+    written_bytes += write_sm_chart_field(&chart.difficulty_str, out)?;
+    written_bytes += write_sm_chart_field(&chart.rating_str, out)?;
+    written_bytes += write_sm_chart_field(&format_radar_values(chart.cached_radar_values), out)?;
+    written_bytes += write_all!(out, &chart.minimized_note_data)?;
+    written_bytes += write_all!(out, b";\n")?;
+    Ok(written_bytes)
+}
+
+fn serialize_ssc_chart(
+    out: &mut dyn io::Write,
+    chart: &crate::ChartSummary,
+) -> Result<usize, io::Error> {
+    let mut written_bytes = 0;
+    let formatted_radar_values = format_radar_values(chart.cached_radar_values);
+    let chart_properties: Vec<(&[u8], &str)> = vec![
+        (b"NOTEDATA", ""),
+        (b"CHARTNAME", &chart.chart_name_str),
+        (b"STEPSTYPE", &chart.step_type_str),
+        (b"DESCRIPTION", &chart.description_str),
+        // TODO: store chart_style_str on ChartSummary
+        (b"CHARTSTYLE", ""),
+        (b"DIFFICULTY", &chart.difficulty_str),
+        (b"METER", &chart.rating_str),
+        (b"RADARVALUES", &formatted_radar_values),
+        (b"CREDIT", &chart.step_artist_str),
+    ];
+
+    for property in chart_properties {
+        written_bytes += write_prop(property.0, property.1.as_bytes(), ValueWriter::Plain, out)?;
+    }
+
+    if chart.chart_has_own_timing {
+        written_bytes += serialize_ssc_chart_timing_fields(out, chart)?;
+    }
+
+    written_bytes += write_all!(out, b"#NOTES:\n")?;
+    written_bytes += write_all!(out, &chart.minimized_note_data)?;
+    written_bytes += write_all!(out, b";\n")?;
+
+    Ok(written_bytes)
+}
+
+fn serialize_ssc_chart_timing_fields(
+    out: &mut dyn io::Write,
+    chart: &crate::ChartSummary,
+) -> Result<usize, io::Error> {
+    use ValueWriter::*;
+
+    let mut written_bytes = 0;
+    let formatted_chart_offset = format_dot6_f64(chart.chart_offset_seconds);
+    let chart_timing_properties: Vec<(&[u8], &str, ValueWriter, bool)> = vec![
+        (b"OFFSET", &formatted_chart_offset, Plain, true),
+        (
+            b"BPMS",
+            &chart.chart_bpms.as_deref().unwrap_or_else(|| DEFAULT_BPMS),
+            List,
+            true,
+        ),
+        (
+            b"STOPS",
+            chart.chart_stops.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"DELAYS",
+            chart.chart_delays.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"WARPS",
+            chart.chart_warps.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"TIMESIGNATURES",
+            chart
+                .chart_time_signatures
+                .as_deref()
+                .unwrap_or_else(|| DEFAULT_TIME_SIGNATURES),
+            List,
+            true,
+        ),
+        (
+            b"TICKCOUNTS",
+            chart.chart_tickcounts.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"COMBOS",
+            chart.chart_combos.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"SPEEDS",
+            chart
+                .chart_speeds
+                .as_deref()
+                .unwrap_or_else(|| DEFAULT_SPEEDS),
+            List,
+            true,
+        ),
+        (
+            b"SCROLLS",
+            chart
+                .chart_scrolls
+                .as_deref()
+                .unwrap_or_else(|| DEFAULT_SCROLLS),
+            List,
+            true,
+        ),
+        (
+            b"FAKES",
+            chart.chart_fakes.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"LABELS",
+            chart.chart_labels.as_deref().unwrap_or_default(),
+            List,
+            true,
+        ),
+        (
+            b"ATTACKS",
+            chart.chart_attacks.as_deref().unwrap_or_default(),
+            List,
+            !chart.chart_attacks.as_ref().is_none_or(|v| v.is_empty()),
+        ),
+        (
+            b"DISPLAYBPM",
+            chart.chart_display_bpm.as_deref().unwrap_or_default(),
+            Plain,
+            !chart
+                .chart_display_bpm
+                .as_ref()
+                .is_none_or(|v| v.is_empty()),
+        ),
+    ];
+
+    for property in chart_timing_properties {
+        if property.3 {
+            written_bytes += write_prop(property.0, property.1.as_bytes(), property.2, out)?;
+        }
+    }
+
+    Ok(written_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use std::io;
+    use std::sync::Arc;
+
+    #[test]
+    fn serialize_simfile_with_ssc() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields();
+        summary.charts.push(chart_summary_with_all_fields(false));
+        summary.charts.push(chart_summary_with_all_fields(true));
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+            super::serialize_simfile(&summary, "ssc", &mut cursor)?;
+            cursor.get_ref()
+        };
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        let expected = "#VERSION:0.83;\n\
+            #TITLE:Title;\n\
+            #SUBTITLE:Subtitle;\n\
+            #ARTIST:Artist;\n\
+            #TITLETRANSLIT:Title translit;\n\
+            #SUBTITLETRANSLIT:Subtitle translit;\n\
+            #ARTISTTRANSLIT:Artist translit;\n\
+            #GENRE:Genre;\n\
+            #ORIGIN:;\n\
+            #CREDIT:;\n\
+            #BANNER:banner.png;\n\
+            #BACKGROUND:background.png;\n\
+            #PREVIEWVID:;\n\
+            #JACKET:jacket.png;\n\
+            #CDIMAGE:;\n\
+            #DISCIMAGE:;\n\
+            #LYRICSPATH:;\n\
+            #CDTITLE:cdtitle.png;\n\
+            #MUSIC:music.ogg;\n\
+            #OFFSET:0.123000;\n\
+            #SAMPLESTART:10.000000;\n\
+            #SAMPLELENGTH:16.000000;\n\
+            #SELECTABLE:YES;\n\
+            #DISPLAYBPM:150;\n\
+            #BPMS:0.000=120.000,\n\
+            16.000=240.000,\n\
+            48.000=120.000;\n\
+            #STOPS:1.000=1.250,\n\
+            1.500=1.750;\n\
+            #DELAYS:2.000=2.250,\n\
+            2.500=2.750;\n\
+            #WARPS:3.000=3.250,\n\
+            3.500=3.750;\n\
+            #TIMESIGNATURES:0.000=4=4,\n\
+            16.000=8=4,\n\
+            48.000=4=4;\n\
+            #TICKCOUNTS:0.000=4,\n\
+            16.000=2,\n\
+            48.000=4;\n\
+            #COMBOS:0.000=1,\n\
+            16.000=2,\n\
+            48.000=1;\n\
+            #SPEEDS:0.000=1.000=0.000=0,\n\
+            12.000=0.500=4.000=0,\n\
+            48.000=1.000=0.000=1;\n\
+            #SCROLLS:0.000=1.000,\n\
+            16.000=2.000,\n\
+            48.000=1.000;\n\
+            #FAKES:4.000=4.250,\n\
+            4.500=4.750;\n\
+            #LABELS:0.000=Song Start,\n\
+            16.000=Speedup;\n\
+            #BGCHANGES:;\n\
+            #KEYSOUNDS:;\n\
+            #ATTACKS:;\n\
+            \n\
+            #NOTEDATA:;\n\
+            #CHARTNAME:Chart name;\n\
+            #STEPSTYPE:dance-single;\n\
+            #DESCRIPTION:Description;\n\
+            #CHARTSTYLE:;\n\
+            #DIFFICULTY:Challenge;\n\
+            #METER:17;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
+            #CREDIT:Step artist;\n\
+            #NOTES:\n\
+            ;\n\
+            \n\
+            #NOTEDATA:;\n\
+            #CHARTNAME:Chart name;\n\
+            #STEPSTYPE:dance-single;\n\
+            #DESCRIPTION:Description;\n\
+            #CHARTSTYLE:;\n\
+            #DIFFICULTY:Challenge;\n\
+            #METER:17;\n\
+            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
+            #CREDIT:Step artist;\n\
+            #OFFSET:0.000000;\n\
+            #BPMS:0.000=120.000,\n\
+            16.000=240.000,\n\
+            48.000=120.000;\n\
+            #STOPS:1.000=1.250,\n\
+            1.500=1.750;\n\
+            #DELAYS:2.000=2.250,\n\
+            2.500=2.750;\n\
+            #WARPS:3.000=3.250,\n\
+            3.500=3.750;\n\
+            #TIMESIGNATURES:0.000=4=4,\n\
+            16.000=8=4,\n\
+            48.000=4=4;\n\
+            #TICKCOUNTS:0.000=4,\n\
+            16.000=2,\n\
+            48.000=4;\n\
+            #COMBOS:0.000=1,\n\
+            16.000=2,\n\
+            48.000=1;\n\
+            #SPEEDS:0.000=1.000=0.000=0,\n\
+            12.000=0.500=4.000=0,\n\
+            48.000=1.000=0.000=1;\n\
+            #SCROLLS:0.000=1.000,\n\
+            16.000=2.000,\n\
+            48.000=1.000;\n\
+            #FAKES:4.000=4.250,\n\
+            4.500=4.750;\n\
+            #LABELS:0.000=Song Start,\n\
+            16.000=Speedup;\n\
+            #DISPLAYBPM:150;\n\
+            #NOTES:\n\
+            ;\n\
+            \n";
+
+        assert_eq!(expected, output);
+
+        Ok(())
+    }
+
+    fn simfile_summary_with_all_fields() -> crate::SimfileSummary {
+        crate::SimfileSummary {
+            title_str: String::from("Title"),
+            subtitle_str: String::from("Subtitle"),
+            artist_str: String::from("Artist"),
+            genre_str: String::from("Genre"),
+            titletranslit_str: String::from("Title translit"),
+            subtitletranslit_str: String::from("Subtitle translit"),
+            artisttranslit_str: String::from("Artist translit"),
+            offset: 0.123,
+            normalized_bpms: String::from("0.000=120.000,16.000=240.000,48.000=120.000"),
+            normalized_stops: String::from("1.000=1.250,1.500=1.750"),
+            normalized_delays: String::from("2.000=2.250,2.500=2.750"),
+            normalized_warps: String::from("3.000=3.250,3.500=3.750"),
+            normalized_speeds: String::from(
+                "0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1",
+            ),
+            normalized_scrolls: String::from("0.000=1.000,16.000=2.000,48.000=1.000"),
+            normalized_fakes: String::from("4.000=4.250,4.500=4.750"),
+            normalized_time_signatures: String::from("0.000=4=4,16.000=8=4,48.000=4=4"),
+            normalized_labels: String::from("0.000=Song Start,16.000=Speedup"),
+            normalized_tickcounts: String::from("0.000=4,16.000=2,48.000=4"),
+            normalized_combos: String::from("0.000=1,16.000=2,48.000=1"),
+            ssc_version: 0.83,
+            timing_format: rssp_core::timing::TimingFormat::Ssc,
+            banner_path: String::from("banner.png"),
+            background_path: String::from("background.png"),
+            cdtitle_path: String::from("cdtitle.png"),
+            jacket_path: String::from("jacket.png"),
+            music_path: String::from("music.ogg"),
+            display_bpm_str: String::from("150"),
+            sample_start: 10.0,
+            sample_length: 16.0,
+
+            // To be populated by the test
+            charts: vec![],
+
+            // The remaining fields are irrelevant to serialization
+            min_bpm: Default::default(),
+            max_bpm: Default::default(),
+            median_bpm: Default::default(),
+            average_bpm: Default::default(),
+            total_length: Default::default(),
+            pattern_counts_enabled: Default::default(),
+            tech_counts_enabled: Default::default(),
+            total_elapsed: Default::default(),
+        }
+    }
+
+    fn chart_summary_with_all_fields(has_own_timing: bool) -> crate::ChartSummary {
+        crate::ChartSummary {
+            step_type_str: String::from("dance-single"),
+            step_artist_str: String::from("Step artist"),
+            description_str: String::from("Description"),
+            chart_name_str: String::from("Chart name"),
+            difficulty_str: String::from("Challenge"),
+            rating_str: String::from("17"),
+            cached_radar_values: Some([
+                0.010, 0.020, 0.030, 0.040, 0.050, 0.060, 0.070, 0.080, 0.090, 0.100, 0.110, 0.120,
+                0.130, 0.140,
+            ]),
+            tech_notation_str: String::from("BR FS XO"),
+            minimized_note_data: Default::default(), // TODO
+
+            // Timing fields
+            chart_has_own_timing: has_own_timing,
+            music_path: match has_own_timing {
+                true => String::from("music.ogg"),
+                false => String::from(""),
+            },
+            chart_attacks: Default::default(), // TODO
+            chart_bpms: has_own_timing
+                .then(|| String::from("0.000=120.000,16.000=240.000,48.000=120.000")),
+            chart_stops: has_own_timing.then(|| String::from("1.000=1.250,1.500=1.750")),
+            chart_delays: has_own_timing.then(|| String::from("2.000=2.250,2.500=2.750")),
+            chart_warps: has_own_timing.then(|| String::from("3.000=3.250,3.500=3.750")),
+            chart_speeds: has_own_timing.then(|| {
+                String::from("0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1")
+            }),
+            chart_scrolls: has_own_timing
+                .then(|| String::from("0.000=1.000,16.000=2.000,48.000=1.000")),
+            chart_fakes: has_own_timing.then(|| String::from("4.000=4.250,4.500=4.750")),
+            chart_time_signatures: has_own_timing
+                .then(|| String::from("0.000=4=4,16.000=8=4,48.000=4=4")),
+            chart_labels: has_own_timing.then(|| String::from("0.000=Song Start,16.000=Speedup")),
+            chart_tickcounts: has_own_timing.then(|| String::from("0.000=4,16.000=2,48.000=4")),
+            chart_combos: has_own_timing.then(|| String::from("0.000=1,16.000=2,48.000=1")),
+            chart_display_bpm: has_own_timing.then(|| String::from("150")),
+
+            // The remaining fields are irrelevant to serialization
+            timing_segments: Arc::new(crate::timing::TimingSegments {
+                beat0_offset_adjust: Default::default(),
+                bpms: Default::default(),
+                stops: Default::default(),
+                delays: Default::default(),
+                warps: Default::default(),
+                speeds: Default::default(),
+                scrolls: Default::default(),
+                fakes: Default::default(),
+            }),
+            matrix_rating: Default::default(),
+            tier_bpm: Default::default(),
+            stats: Default::default(),
+            stream_counts: Default::default(),
+            total_measures: Default::default(),
+            total_streams: Default::default(),
+            mines_nonfake: Default::default(),
+            sn_detailed_breakdown: Default::default(),
+            sn_partial_breakdown: Default::default(),
+            sn_simple_breakdown: Default::default(),
+            detailed_breakdown: Default::default(),
+            partial_breakdown: Default::default(),
+            simple_breakdown: Default::default(),
+            max_nps: Default::default(),
+            median_nps: Default::default(),
+            duration_seconds: Default::default(),
+            detected_patterns: [Default::default(); rssp_core::patterns::PATTERN_COUNT],
+            anchor_left: Default::default(),
+            anchor_down: Default::default(),
+            anchor_up: Default::default(),
+            anchor_right: Default::default(),
+            facing_left: Default::default(),
+            facing_right: Default::default(),
+            mono_total: Default::default(),
+            mono_percent: Default::default(),
+            candle_total: Default::default(),
+            candle_percent: Default::default(),
+            tech_counts: Default::default(),
+            note_annotations: Default::default(),
+            custom_patterns: Default::default(),
+            short_hash: Default::default(),
+            bpm_neutral_hash: Default::default(),
+            elapsed: Default::default(),
+            measure_densities: Default::default(),
+            measure_nps_vec: Default::default(),
+            row_to_beat: Default::default(),
+            chart_offset_seconds: Default::default(),
+        }
+    }
 }

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -14,9 +14,20 @@ enum ValueWriter {
     List,
 }
 
+/// Call `write_all` and, on success, return the input's size in bytes
 macro_rules! write_all {
     ($out:expr, $value:expr) => {
         $out.write_all($value).map(|_| $value.len())
+    };
+}
+
+/// Unwrap `Some(String)` to `&str`, or `None` to `""`
+macro_rules! slice_or_default {
+    ($e: expr) => {
+        $e.as_deref().unwrap_or_default()
+    };
+    ($e: expr, $default: expr) => {
+        $e.as_deref().unwrap_or_else(|| $default)
     };
 }
 
@@ -74,6 +85,14 @@ fn format_dot3_f32(value: f32) -> String {
     format!("{:.3}", value)
 }
 
+#[inline(always)]
+fn format_selectable(value: bool) -> String {
+    match value {
+        true => String::from("YES"),
+        false => String::from("NO"),
+    }
+}
+
 fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
     match radar_values {
         Some(radar_values) => radar_values
@@ -100,6 +119,7 @@ pub fn serialize_simfile(
     let formatted_offset = format_dot6_f64(summary.offset);
     let formatted_sample_start = format_dot6_f64(summary.sample_start);
     let formatted_sample_length = format_dot6_f64(summary.sample_length);
+    let formatted_selectable = format_selectable(summary.selectable);
 
     // (key, value, is_included, value_writer)
     let properties: Vec<(&[u8], &str, bool, ValueWriter)> = vec![
@@ -116,21 +136,21 @@ pub fn serialize_simfile(
         ),
         (b"ARTISTTRANSLIT", &summary.artisttranslit_str, true, Plain),
         (b"GENRE", &summary.genre_str, true, Plain),
-        (b"ORIGIN", "", true, Plain), // TODO
-        (b"CREDIT", "", true, Plain), // TODO
+        (b"ORIGIN", &summary.origin_str, ssc, Plain),
+        (b"CREDIT", &summary.credit_str, true, Plain),
         (b"BANNER", &summary.banner_path, true, Plain),
         (b"BACKGROUND", &summary.background_path, true, Plain),
-        (b"PREVIEWVID", "", ssc, Plain), // TODO
+        (b"PREVIEWVID", &summary.previewvid_path, ssc, Plain),
         (b"JACKET", &summary.jacket_path, ssc, Plain),
-        (b"CDIMAGE", "", ssc, Plain),     // TODO
-        (b"DISCIMAGE", "", ssc, Plain),   // TODO
-        (b"LYRICSPATH", "", true, Plain), // TODO
+        (b"CDIMAGE", &summary.cdimage_path, ssc, Plain),
+        (b"DISCIMAGE", &summary.discimage_path, ssc, Plain),
+        (b"LYRICSPATH", &summary.lyrics_path, true, Plain),
         (b"CDTITLE", &summary.cdtitle_path, true, Plain),
         (b"MUSIC", &summary.music_path, true, Plain),
         (b"OFFSET", &formatted_offset, true, Plain),
         (b"SAMPLESTART", &formatted_sample_start, true, Plain),
         (b"SAMPLELENGTH", &formatted_sample_length, true, Plain),
-        (b"SELECTABLE", "YES", true, Plain), // TODO
+        (b"SELECTABLE", &formatted_selectable, true, Plain),
         (
             b"DISPLAYBPM",
             &summary.display_bpm_str,
@@ -153,9 +173,16 @@ pub fn serialize_simfile(
         (b"SCROLLS", &summary.normalized_scrolls, ssc, List),
         (b"FAKES", &summary.normalized_fakes, ssc, List),
         (b"LABELS", &summary.normalized_labels, ssc, List),
-        (b"BGCHANGES", "", true, List), // TODO
-        (b"KEYSOUNDS", "", true, List), // TODO
-        (b"ATTACKS", "", true, List),   // TODO
+        (b"BGCHANGES", &summary.normalized_bgchanges, true, List),
+        (
+            b"FGCHANGES",
+            &summary.normalized_fgchanges,
+            !summary.normalized_fgchanges.is_empty(),
+            List,
+        ),
+        (b"KEYSOUNDS", &summary.normalized_keysounds, true, List),
+        // TODO: make sure the implementation for this meshes well with the original ATTACKS implementation
+        (b"ATTACKS", &summary.normalized_attacks, true, List),
     ];
 
     for (key, value, is_included, value_writer) in properties {
@@ -211,8 +238,7 @@ fn serialize_ssc_chart(
         (b"CHARTNAME", &chart.chart_name_str),
         (b"STEPSTYPE", &chart.step_type_str),
         (b"DESCRIPTION", &chart.description_str),
-        // TODO: store chart_style_str on ChartSummary
-        (b"CHARTSTYLE", ""),
+        (b"CHARTSTYLE", &chart.chart_style_str),
         (b"DIFFICULTY", &chart.difficulty_str),
         (b"METER", &chart.rating_str),
         (b"RADARVALUES", &formatted_radar_values),
@@ -246,88 +272,49 @@ fn serialize_ssc_chart_timing_fields(
         (b"OFFSET", &formatted_chart_offset, Plain, true),
         (
             b"BPMS",
-            &chart.chart_bpms.as_deref().unwrap_or_else(|| DEFAULT_BPMS),
+            slice_or_default!(chart.chart_bpms, DEFAULT_BPMS),
             List,
             true,
         ),
-        (
-            b"STOPS",
-            chart.chart_stops.as_deref().unwrap_or_default(),
-            List,
-            true,
-        ),
-        (
-            b"DELAYS",
-            chart.chart_delays.as_deref().unwrap_or_default(),
-            List,
-            true,
-        ),
-        (
-            b"WARPS",
-            chart.chart_warps.as_deref().unwrap_or_default(),
-            List,
-            true,
-        ),
+        (b"STOPS", slice_or_default!(chart.chart_stops), List, true),
+        (b"DELAYS", slice_or_default!(chart.chart_delays), List, true),
+        (b"WARPS", slice_or_default!(chart.chart_warps), List, true),
         (
             b"TIMESIGNATURES",
-            chart
-                .chart_time_signatures
-                .as_deref()
-                .unwrap_or_else(|| DEFAULT_TIME_SIGNATURES),
+            slice_or_default!(chart.chart_time_signatures, DEFAULT_TIME_SIGNATURES),
             List,
             true,
         ),
         (
             b"TICKCOUNTS",
-            chart.chart_tickcounts.as_deref().unwrap_or_default(),
+            slice_or_default!(chart.chart_tickcounts),
             List,
             true,
         ),
-        (
-            b"COMBOS",
-            chart.chart_combos.as_deref().unwrap_or_default(),
-            List,
-            true,
-        ),
+        (b"COMBOS", slice_or_default!(chart.chart_combos), List, true),
         (
             b"SPEEDS",
-            chart
-                .chart_speeds
-                .as_deref()
-                .unwrap_or_else(|| DEFAULT_SPEEDS),
+            slice_or_default!(chart.chart_speeds, DEFAULT_SPEEDS),
             List,
             true,
         ),
         (
             b"SCROLLS",
-            chart
-                .chart_scrolls
-                .as_deref()
-                .unwrap_or_else(|| DEFAULT_SCROLLS),
+            slice_or_default!(chart.chart_scrolls, DEFAULT_SCROLLS),
             List,
             true,
         ),
-        (
-            b"FAKES",
-            chart.chart_fakes.as_deref().unwrap_or_default(),
-            List,
-            true,
-        ),
-        (
-            b"LABELS",
-            chart.chart_labels.as_deref().unwrap_or_default(),
-            List,
-            true,
-        ),
+        (b"FAKES", slice_or_default!(chart.chart_fakes), List, true),
+        (b"LABELS", slice_or_default!(chart.chart_labels), List, true),
         (
             b"ATTACKS",
-            chart.chart_attacks.as_deref().unwrap_or_default(),
+            slice_or_default!(chart.chart_attacks),
             List,
             !chart.chart_attacks.as_ref().is_none_or(|v| v.is_empty()),
         ),
         (
             b"DISPLAYBPM",
-            chart.chart_display_bpm.as_deref().unwrap_or_default(),
+            slice_or_default!(chart.chart_display_bpm),
             Plain,
             !chart
                 .chart_display_bpm
@@ -373,15 +360,15 @@ mod tests {
             #SUBTITLETRANSLIT:Subtitle translit;\n\
             #ARTISTTRANSLIT:Artist translit;\n\
             #GENRE:Genre;\n\
-            #ORIGIN:;\n\
-            #CREDIT:;\n\
+            #ORIGIN:Origin;\n\
+            #CREDIT:Credit;\n\
             #BANNER:banner.png;\n\
             #BACKGROUND:background.png;\n\
-            #PREVIEWVID:;\n\
+            #PREVIEWVID:previewvid.mov;\n\
             #JACKET:jacket.png;\n\
-            #CDIMAGE:;\n\
-            #DISCIMAGE:;\n\
-            #LYRICSPATH:;\n\
+            #CDIMAGE:cdimage.png;\n\
+            #DISCIMAGE:discimage.png;\n\
+            #LYRICSPATH:lyrics.lrc;\n\
             #CDTITLE:cdtitle.png;\n\
             #MUSIC:music.ogg;\n\
             #OFFSET:0.123000;\n\
@@ -425,7 +412,7 @@ mod tests {
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
             #DESCRIPTION:Description;\n\
-            #CHARTSTYLE:;\n\
+            #CHARTSTYLE:Chart style;\n\
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
             #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
@@ -441,7 +428,7 @@ mod tests {
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
             #DESCRIPTION:Description;\n\
-            #CHARTSTYLE:;\n\
+            #CHARTSTYLE:Chart style;\n\
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
             #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
@@ -510,11 +497,10 @@ mod tests {
         #SUBTITLETRANSLIT:Subtitle translit;\n\
         #ARTISTTRANSLIT:Artist translit;\n\
         #GENRE:Genre;\n\
-        #ORIGIN:;\n\
-        #CREDIT:;\n\
+        #CREDIT:Credit;\n\
         #BANNER:banner.png;\n\
         #BACKGROUND:background.png;\n\
-        #LYRICSPATH:;\n\
+        #LYRICSPATH:lyrics.lrc;\n\
         #CDTITLE:cdtitle.png;\n\
         #MUSIC:music.ogg;\n\
         #OFFSET:0.123000;\n\
@@ -584,6 +570,17 @@ mod tests {
             display_bpm_str: String::from("150"),
             sample_start: 10.0,
             sample_length: 16.0,
+            origin_str: String::from("Origin"),
+            credit_str: String::from("Credit"),
+            normalized_bgchanges: Default::default(), // TODO
+            normalized_fgchanges: Default::default(), // TODO
+            normalized_keysounds: Default::default(), // TODO
+            normalized_attacks: Default::default(),   // TODO
+            previewvid_path: String::from("previewvid.mov"),
+            cdimage_path: String::from("cdimage.png"),
+            discimage_path: String::from("discimage.png"),
+            lyrics_path: String::from("lyrics.lrc"),
+            selectable: true,
 
             // To be populated by the test
             charts: vec![],
@@ -606,6 +603,7 @@ mod tests {
             step_artist_str: String::from("Step artist"),
             description_str: String::from("Description"),
             chart_name_str: String::from("Chart name"),
+            chart_style_str: String::from("Chart style"),
             difficulty_str: String::from("Challenge"),
             rating_str: String::from("17"),
             cached_radar_values: Some([

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -61,25 +61,6 @@ fn format_dot3_f32(value: f32) -> String {
     format!("{:.3}", value)
 }
 
-#[must_use]
-#[inline(always)]
-fn format_radar_values(radar_values: Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>) -> String {
-    match radar_values {
-        Some(radar_values) => radar_values
-            .iter()
-            .map(|&f| format_dot3_f32(f))
-            .collect::<Vec<String>>()
-            .join(","),
-        None => String::from(""),
-    }
-}
-
-enum ListItem<'a> {
-    Float(f64),
-    Int(i32),
-    Str(&'a str),
-}
-
 #[derive(Default)]
 enum PropValue<'a> {
     #[default]
@@ -94,15 +75,6 @@ enum PropValue<'a> {
     Bool(bool),
     NormalizedList(&'a str),
     NormalizedListOpt(Option<&'a str>),
-    // TODO: decide if we actually need these.
-    // Currently only charts store timing fields like this and they're redundant with the normalized forms.
-    List(&'a [[Option<ListItem<'a>>; 4]]),
-    Pairs(&'a [(f64, f64)]),
-    TimeSignatures(&'a [(f64, i32, i32)]),
-    Labels(&'a [(f64, String)]),
-    TickCounts(&'a [(f64, i32)]),
-    Combos(&'a [(f64, i32, i32)]),
-    Speeds(&'a [(f64, f64, f64, i32)]),
     RadarValues(Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>),
 }
 
@@ -152,119 +124,6 @@ impl<'a> PropValue<'a> {
                 None => Ok(0),
                 Some(items_str) => NormalizedList(items_str).serialize(out),
             },
-            List(items) => {
-                let mut written_bytes = 0;
-                let mut first_row = true;
-
-                for row in *items {
-                    if !first_row {
-                        written_bytes += write_all!(out, b",\n")?;
-                    }
-                    let mut first_item = true;
-                    for item in row {
-                        if !first_item {
-                            written_bytes += write_all!(out, b"=")?;
-                        }
-                        written_bytes += match item {
-                            Some(ListItem::Float(f)) => {
-                                write_all!(out, format_dot6_f64(*f).as_bytes())?
-                            }
-                            Some(ListItem::Int(i)) => write_all!(out, i.to_string().as_bytes())?,
-                            Some(ListItem::Str(s)) => sm_escape(out, s.as_bytes())?,
-                            None => break,
-                        };
-                        first_item = false;
-                    }
-                    first_row = false;
-                }
-
-                Ok(written_bytes)
-            }
-            Pairs(rows) => List(
-                rows.iter()
-                    .map(|row| {
-                        [
-                            Some(ListItem::Float(row.0)),
-                            Some(ListItem::Float(row.1)),
-                            None,
-                            None,
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .serialize(out),
-            TimeSignatures(rows) => List(
-                rows.iter()
-                    .map(|row| {
-                        [
-                            Some(ListItem::Float(row.0)),
-                            Some(ListItem::Int(row.1)),
-                            Some(ListItem::Int(row.2)),
-                            None,
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .serialize(out),
-
-            Labels(rows) => List(
-                rows.iter()
-                    .map(|row| {
-                        [
-                            Some(ListItem::Float(row.0)),
-                            Some(ListItem::Str(&row.1)),
-                            None,
-                            None,
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .serialize(out),
-            TickCounts(rows) => List(
-                rows.iter()
-                    .map(|row| {
-                        [
-                            Some(ListItem::Float(row.0)),
-                            Some(ListItem::Int(row.1)),
-                            None,
-                            None,
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .serialize(out),
-            Combos(rows) => List(
-                rows.iter()
-                    .map(|row| {
-                        [
-                            Some(ListItem::Float(row.0)),
-                            Some(ListItem::Int(row.1)),
-                            None,
-                            None,
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .serialize(out),
-            Speeds(rows) => List(
-                rows.iter()
-                    .map(|row| {
-                        [
-                            Some(ListItem::Float(row.0)),
-                            Some(ListItem::Float(row.1)),
-                            Some(ListItem::Float(row.2)),
-                            Some(ListItem::Int(row.3)),
-                        ]
-                    })
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            )
-            .serialize(out),
             RadarValues(rv) => match rv {
                 Some(values) => {
                     let mut written_bytes = 0;
@@ -300,13 +159,6 @@ impl<'a> PropValue<'a> {
             Bool(_) => false,
             NormalizedList(s) => s.is_empty(),
             NormalizedListOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
-            List(rows) => rows.is_empty(),
-            Pairs(rows) => rows.is_empty(),
-            TimeSignatures(rows) => rows.is_empty(),
-            Labels(rows) => rows.is_empty(),
-            TickCounts(rows) => rows.is_empty(),
-            Combos(rows) => rows.is_empty(),
-            Speeds(rows) => rows.is_empty(),
             RadarValues(rv) => rv.is_none(),
         }
     }
@@ -534,16 +386,6 @@ pub fn serialize_simfile(
         written_bytes += write_all!(out, b"\n")?;
     }
 
-    Ok(written_bytes)
-}
-
-#[must_use]
-#[inline(always)]
-fn write_sm_chart_field(value: &str, out: &mut dyn io::Write) -> io::Result<usize> {
-    let mut written_bytes = 0;
-    written_bytes += write_all!(out, b"     ")?;
-    written_bytes += out.write(value.as_bytes())?;
-    written_bytes += write_all!(out, b":\n")?;
     Ok(written_bytes)
 }
 

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -1329,6 +1329,7 @@ mod tests {
             measure_nps_vec: Default::default(),
             row_to_beat: Default::default(),
             chart_offset_seconds: Default::default(),
+            matrix_profile: Default::default(),
         }
     }
 }

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -66,9 +66,9 @@ enum PropValue<'a> {
     #[default]
     Empty,
     Str(&'a str),
-    StrOpt(Option<&'a str>),
+    StrNoEscape(&'a str),
+    StrNoEscapeOpt(Option<&'a str>),
     Bytes(&'a [u8]),
-    BytesOpt(Option<&'a [u8]>),
     NoteData(&'a [u8]),
     Version(f32),
     Number(f64),
@@ -85,15 +85,12 @@ impl<'a> PropValue<'a> {
         match self {
             PropValue::Empty => Ok(0),
             PropValue::Str(s) => sm_escape(out, s.as_bytes()),
-            PropValue::StrOpt(opt) => match opt {
+            PropValue::StrNoEscape(s) => write_all!(out, s.as_bytes()),
+            PropValue::StrNoEscapeOpt(opt) => match opt {
                 None => Ok(0),
-                Some(s) => PropValue::Str(s).serialize(out),
+                Some(s) => PropValue::StrNoEscape(*s).serialize(out),
             },
             PropValue::Bytes(b) => write_all!(out, b),
-            PropValue::BytesOpt(opt) => match opt {
-                None => Ok(0),
-                Some(b) => PropValue::Bytes(*b).serialize(out),
-            },
             PropValue::NoteData(b) => Ok(write_all!(out, b"\n")? + write_all!(out, b)?),
             PropValue::Version(v) => write_all!(out, format_version(*v).as_bytes()),
             PropValue::Number(n) => write_all!(out, format_dot6_f64(*n).as_bytes()),
@@ -158,9 +155,9 @@ impl<'a> PropValue<'a> {
         match self {
             PropValue::Empty => true,
             PropValue::Str(s) => s.is_empty(),
-            PropValue::StrOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
+            PropValue::StrNoEscape(s) => s.is_empty(),
+            PropValue::StrNoEscapeOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
             PropValue::Bytes(b) => b.is_empty(),
-            PropValue::BytesOpt(opt) => opt.as_ref().is_none_or(|b| b.is_empty()),
             PropValue::NoteData(_) => false,
             PropValue::Version(v) => !v.is_finite(),
             PropValue::Number(_) => false,
@@ -329,7 +326,7 @@ pub fn serialize_simfile(
         Prop::new(b"SAMPLESTART", PropValue::Number(summary.sample_start)),
         Prop::new(b"SAMPLELENGTH", PropValue::Number(summary.sample_length)),
         Prop::new(b"SELECTABLE", PropValue::Bool(summary.selectable)),
-        Prop::nonempty_only(b"DISPLAYBPM", PropValue::Bytes(&summary.display_bpm_str.as_bytes())), // Don't escape the ':' in ranges
+        Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscape(&summary.display_bpm_str)),
         Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedList(&summary.normalized_bpms)),
         Prop::new(b"STOPS", PropValue::NormalizedList(&summary.normalized_stops)),
         Prop::ssc_only(b"DELAYS", PropValue::NormalizedList(&summary.normalized_delays)),
@@ -342,10 +339,10 @@ pub fn serialize_simfile(
         Prop::ssc_only(b"FAKES", PropValue::NormalizedList(&summary.normalized_fakes)),
         Prop::ssc_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedList(&summary.normalized_labels)),
         Prop::ssc_nonempty_only(b"LASTSECONDHINT", PropValue::NumberOpt(summary.last_second_hint)),
-        Prop::new(b"BGCHANGES", PropValue::NormalizedList(&summary.normalized_bgchanges)),
-        Prop::nonempty_only(b"FGCHANGES", PropValue::NormalizedList(&summary.normalized_fgchanges)),
+        Prop::new(b"BGCHANGES", PropValue::StrNoEscape(&summary.normalized_bgchanges)),
+        Prop::nonempty_only(b"FGCHANGES", PropValue::StrNoEscape(&summary.normalized_fgchanges)),
         Prop::new(b"KEYSOUNDS", PropValue::NormalizedList(&summary.normalized_keysounds)),
-        Prop::new(b"ATTACKS", PropValue::Bytes(summary.normalized_attacks.as_bytes())), // Commas aren't always row separators
+        Prop::new(b"ATTACKS", PropValue::StrNoEscape(&summary.normalized_attacks)), // Commas aren't always row separators
     ];
 
     for prop in props {
@@ -425,8 +422,8 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedListOpt(chart.chart_scrolls.as_deref())),
         Prop::own_timing_only(b"FAKES", PropValue::NormalizedListOpt(chart.chart_fakes.as_deref())),
         Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedListOpt(chart.chart_labels.as_deref())),
-        Prop::nonempty_only(b"ATTACKS", PropValue::BytesOpt(chart.chart_attacks.as_deref().map(|a| a.as_bytes()))),
-        Prop::nonempty_only(b"DISPLAYBPM", PropValue::BytesOpt(chart.chart_display_bpm.as_ref().map(|v| v.as_bytes()))),
+        Prop::nonempty_only(b"ATTACKS", PropValue::StrNoEscapeOpt(chart.chart_attacks.as_deref())),
+        Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscapeOpt(chart.chart_display_bpm.as_deref())),
         Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
         Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO
     ];

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -347,7 +347,6 @@ mod tests {
         {
             let mut cursor = io::Cursor::new(&mut buffer);
             super::serialize_simfile(&summary, "ssc", &mut cursor)?;
-            cursor.get_ref()
         };
 
         let output = String::from_utf8(buffer).unwrap();
@@ -485,7 +484,6 @@ mod tests {
         {
             let mut cursor = io::Cursor::new(&mut buffer);
             super::serialize_simfile(&summary, "sm", &mut cursor)?;
-            cursor.get_ref()
         };
 
         let output = String::from_utf8(buffer).unwrap();

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -1,6 +1,9 @@
-use std::io;
+use std::{borrow::Cow, io};
 
-use rssp_core::{parse::extension_is_ssc, timing::SpeedUnit};
+use rssp_core::{
+    parse::extension_is_ssc,
+    timing::{SpeedUnit, convert_warps_and_delays_to_sm_stops},
+};
 
 pub const DEFAULT_VERSION: &[u8] = b"0.83";
 pub const DEFAULT_TITLE: &[u8] = b"Untitled";
@@ -319,6 +322,17 @@ pub fn serialize_simfile(
         }
     }
 
+    let stops = if ssc {
+        Cow::Borrowed(summary.global_timing_segments.stops.as_slice())
+    } else {
+        convert_warps_and_delays_to_sm_stops(
+            &summary.global_timing_segments.bpms,
+            &summary.global_timing_segments.stops,
+            &summary.global_timing_segments.delays,
+            &summary.global_timing_segments.warps,
+        )
+    };
+
     let mut written_bytes = 0;
 
     #[rustfmt::skip]
@@ -348,7 +362,7 @@ pub fn serialize_simfile(
         Prop::new(b"SELECTABLE", PropValue::Bool(summary.selectable)),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscape(&summary.display_bpm_str)),
         Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::TimingPairs(&summary.global_timing_segments.bpms)),
-        Prop::new(b"STOPS", PropValue::TimingPairs(&summary.global_timing_segments.stops)),
+        Prop::new(b"STOPS", PropValue::TimingPairs(&stops)),
         Prop::ssc_only(b"DELAYS", PropValue::TimingPairs(&summary.global_timing_segments.delays)),
         Prop::ssc_only(b"WARPS", PropValue::TimingPairs(&summary.global_timing_segments.warps)),
         Prop::ssc_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::StrNoEscape(&summary.normalized_time_signatures)),
@@ -362,7 +376,7 @@ pub fn serialize_simfile(
         Prop::new(b"BGCHANGES", PropValue::StrNoEscape(&summary.normalized_bgchanges)),
         Prop::nonempty_only(b"FGCHANGES", PropValue::StrNoEscape(&summary.normalized_fgchanges)),
         Prop::new(b"KEYSOUNDS", PropValue::StrNoEscape(&summary.normalized_keysounds)),
-        Prop::new(b"ATTACKS", PropValue::StrNoEscape(&summary.normalized_attacks)), // Commas aren't always row separators
+        Prop::new(b"ATTACKS", PropValue::StrNoEscape(&summary.normalized_attacks)),
     ];
 
     for prop in props {
@@ -932,7 +946,11 @@ mod tests {
         16.000000=240.000000,\n\
         48.000000=120.000000;\n\
         #STOPS:1.000000=1.250000,\n\
-        1.500000=1.750000;\n\
+        1.500000=1.750000,\n\
+        2.000000=2.250000,\n\
+        2.500000=2.750000,\n\
+        3.000000=-1.625000,\n\
+        3.500000=-1.875000;\n\
         #BGCHANGES:BGChanges;\n\
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
@@ -988,7 +1006,11 @@ mod tests {
         16.000000=240.000000,\n\
         48.000000=120.000000;\n\
         #STOPS:1.000000=1.250000,\n\
-        1.500000=1.750000;\n\
+        1.500000=1.750000,\n\
+        2.000000=2.250000,\n\
+        2.500000=2.750000,\n\
+        3.000000=-1.625000,\n\
+        3.500000=-1.875000;\n\
         #BGCHANGES:BGChanges;\n\
         #FGCHANGES:FGChanges;\n\
         #KEYSOUNDS:;\n\

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -178,7 +178,6 @@ pub fn serialize_simfile(
                 written_bytes += serialize_sm_chart_field(&chart.description_str, out)?;
                 written_bytes += serialize_sm_chart_field(&chart.difficulty_str, out)?;
                 written_bytes += serialize_sm_chart_field(&chart.rating_str, out)?;
-                // TODO: verify whether this actually mirrors the "description" field
                 written_bytes +=
                     serialize_sm_chart_field(&format_radar_values(chart.cached_radar_values), out)?;
                 written_bytes += out.write(&chart.minimized_note_data)?;

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -489,7 +489,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::nonempty_only(b"ATTACKS", PropValue::StrNoEscapeOpt(chart.chart_has_own_attacks.then(|| chart.chart_attacks.as_deref()).flatten())),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscapeOpt(chart.chart_display_bpm.as_deref())),
         Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
-        Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO
+        Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO: write NOTES2 instead of NOTES as needed
     ];
 
     for prop in props {
@@ -574,8 +574,9 @@ mod tests {
             4.500000=4.750000;\n\
             #LABELS:0.000000=Song Start,\n\
             16.000000=Speedup;\n\
-            #BGCHANGES:BGChanges;\n\
-            #KEYSOUNDS:;\n\
+            #BGCHANGES:99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n\
+            ;\n\
+            #KEYSOUNDS:a.ogg,b.ogg.c.ogg;\n\
             #ATTACKS:;\n\
             \n\
             //---------------dance-single - Description----------------\n\
@@ -590,9 +591,13 @@ mod tests {
             0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #NOTES:\n\
+            1000\n\
             0000\n\
+            0100\n\
+            00M0\n\
+            0100\n\
             0000\n\
-            0000\n\
+            0001\n\
             0000\n\
             ;\n\
             \n\
@@ -637,9 +642,13 @@ mod tests {
             #LABELS:0.000000=Song Start,\n\
             116.000000=Speedup;\n\
             #NOTES:\n\
+            1000\n\
             0000\n\
+            0100\n\
+            00M0\n\
+            0100\n\
             0000\n\
-            0000\n\
+            0001\n\
             0000\n\
             ;\n\
             \n";
@@ -719,10 +728,11 @@ mod tests {
             #LABELS:0.000000=Song Start,\n\
             16.000000=Speedup;\n\
             #LASTSECONDHINT:120.000000;\n\
-            #BGCHANGES:BGChanges;\n\
-            #FGCHANGES:FGChanges;\n\
-            #KEYSOUNDS:;\n\
-            #ATTACKS:Attacks;\n\
+            #BGCHANGES:99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n\
+            ;\n\
+            #FGCHANGES:0.000000=lua=1.000000=0=0=1;\n\
+            #KEYSOUNDS:a.ogg,b.ogg.c.ogg;\n\
+            #ATTACKS:TIME=64.000000:LEN=2.000000:MODS=*0.5 stealth;\n\
             \n\
             //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
@@ -736,12 +746,16 @@ mod tests {
             #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000,\
             0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
-            #ATTACKS:Attacks;\n\
+            #ATTACKS:TIME=164.000000:LEN=2.000000:MODS=*0.5 stealth;\n\
             #DISPLAYBPM:300;\n\
             #NOTES:\n\
+            1000\n\
             0000\n\
+            0100\n\
+            00M0\n\
+            0100\n\
             0000\n\
-            0000\n\
+            0001\n\
             0000\n\
             ;\n\
             \n\
@@ -786,12 +800,16 @@ mod tests {
             104.500000=4.750000;\n\
             #LABELS:0.000000=Song Start,\n\
             116.000000=Speedup;\n\
-            #ATTACKS:Attacks;\n\
+            #ATTACKS:TIME=164.000000:LEN=2.000000:MODS=*0.5 stealth;\n\
             #DISPLAYBPM:300;\n\
             #NOTES:\n\
+            1000\n\
             0000\n\
+            0100\n\
+            00M0\n\
+            0100\n\
             0000\n\
-            0000\n\
+            0001\n\
             0000\n\
             ;\n\
             \n";
@@ -852,8 +870,9 @@ mod tests {
             #SCROLLS:0.000000=1.000000;\n\
             #FAKES:;\n\
             #LABELS:0.000000=Song Start;\n\
-            #BGCHANGES:BGChanges;\n\
-            #KEYSOUNDS:;\n\
+            #BGCHANGES:99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n\
+            ;\n\
+            #KEYSOUNDS:a.ogg,b.ogg.c.ogg;\n\
             #ATTACKS:;\n\
             \n\
             //---------------dance-single - Description----------------\n\
@@ -868,9 +887,13 @@ mod tests {
             0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #NOTES:\n\
+            1000\n\
             0000\n\
+            0100\n\
+            00M0\n\
+            0100\n\
             0000\n\
-            0000\n\
+            0001\n\
             0000\n\
             ;\n\
             \n\
@@ -898,9 +921,13 @@ mod tests {
             #FAKES:;\n\
             #LABELS:0.000000=Song Start;\n\
             #NOTES:\n\
+            1000\n\
             0000\n\
+            0100\n\
+            00M0\n\
+            0100\n\
             0000\n\
-            0000\n\
+            0001\n\
             0000\n\
             ;\n\
             \n";
@@ -951,15 +978,20 @@ mod tests {
         2.500000=2.750000,\n\
         3.000000=-1.625000,\n\
         3.500000=-1.875000;\n\
-        #BGCHANGES:BGChanges;\n\
-        #KEYSOUNDS:;\n\
+        #BGCHANGES:99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n\
+        ;\n\
+        #KEYSOUNDS:a.ogg,b.ogg.c.ogg;\n\
         #ATTACKS:;\n\
         \n\
         //---------------dance-single - Description----------------\n\
         #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
+        1000\n\
         0000\n\
+        0100\n\
+        00M0\n\
+        0100\n\
         0000\n\
-        0000\n\
+        0001\n\
         0000\n\
         ;\n\
         \n";
@@ -1011,16 +1043,21 @@ mod tests {
         2.500000=2.750000,\n\
         3.000000=-1.625000,\n\
         3.500000=-1.875000;\n\
-        #BGCHANGES:BGChanges;\n\
-        #FGCHANGES:FGChanges;\n\
-        #KEYSOUNDS:;\n\
-        #ATTACKS:Attacks;\n\
+        #BGCHANGES:99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n\
+        ;\n\
+        #FGCHANGES:0.000000=lua=1.000000=0=0=1;\n\
+        #KEYSOUNDS:a.ogg,b.ogg.c.ogg;\n\
+        #ATTACKS:TIME=64.000000:LEN=2.000000:MODS=*0.5 stealth;\n\
         \n\
         //---------------dance-single - Description----------------\n\
         #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
+        1000\n\
         0000\n\
+        0100\n\
+        00M0\n\
+        0100\n\
         0000\n\
-        0000\n\
+        0001\n\
         0000\n\
         ;\n\
         \n";
@@ -1064,15 +1101,20 @@ mod tests {
         #SELECTABLE:YES;\n\
         #BPMS:0.000000=60.000000;\n\
         #STOPS:;\n\
-        #BGCHANGES:BGChanges;\n\
-        #KEYSOUNDS:;\n\
+        #BGCHANGES:99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n\
+        ;\n\
+        #KEYSOUNDS:a.ogg,b.ogg.c.ogg;\n\
         #ATTACKS:;\n\
         \n\
         //---------------dance-single - Description----------------\n\
         #NOTES:\n     dance-single:\n     Description:\n     Beginner:\n     1:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
+        1000\n\
         0000\n\
+        0100\n\
+        00M0\n\
+        0100\n\
         0000\n\
-        0000\n\
+        0001\n\
         0000\n\
         ;\n\
         \n";
@@ -1182,15 +1224,17 @@ mod tests {
             sample_length: 16.0,
             origin_str: String::from("Origin"),
             credit_str: String::from("Credit"),
-            normalized_bgchanges: String::from("BGChanges"), // TODO: replace with valid string
+            normalized_bgchanges: String::from(
+                "99999=-nosongbg-=1.000=0=0=0 // don't automatically add -songbackground-\n",
+            ),
             normalized_fgchanges: if include_nonempty {
-                String::from("FGChanges") // TODO: replace with valid string
+                String::from("0.000000=lua=1.000000=0=0=1")
             } else {
                 Default::default()
             },
-            normalized_keysounds: Default::default(), // TODO
+            normalized_keysounds: String::from("a.ogg,b.ogg.c.ogg"),
             normalized_attacks: if include_nonempty {
-                String::from("Attacks") // TODO: replace with valid string
+                String::from("TIME=64.000000:LEN=2.000000:MODS=*0.5 stealth")
             } else {
                 Default::default()
             },
@@ -1243,7 +1287,7 @@ mod tests {
                 0.130, 0.140,
             ]),
             tech_notation_str: String::from("BR FS XO"),
-            minimized_note_data: b"0000\n0000\n0000\n0000\n".to_vec(), // TODO
+            minimized_note_data: b"1000\n0000\n0100\n00M0\n0100\n0000\n0001\n0000\n".to_vec(),
             music_path: match include_nonempty {
                 true => String::from("chart_music.ogg"),
                 false => String::from(""),
@@ -1259,7 +1303,8 @@ mod tests {
                 .then(|| String::from("0.000000=4,\n116.000000=2,\n148.000000=4")),
             chart_combos: (has_own_timing && !trigger_defaults)
                 .then(|| String::from("0.000000=1,\n116.000000=2,\n148.000000=1")),
-            chart_attacks: include_nonempty.then(|| String::from("Attacks")), // TODO
+            chart_attacks: include_nonempty
+                .then(|| String::from("TIME=164.000000:LEN=2.000000:MODS=*0.5 stealth")),
             chart_has_own_attacks: include_nonempty,
             chart_display_bpm: include_nonempty.then(|| String::from("300")),
 

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -162,7 +162,7 @@ impl<'a> PropValue<'a> {
             PropValue::Bytes(b) => b.is_empty(),
             PropValue::BytesOpt(opt) => opt.as_ref().is_none_or(|b| b.is_empty()),
             PropValue::NoteData(_) => false,
-            PropValue::Version(_) => false,
+            PropValue::Version(v) => !v.is_finite(),
             PropValue::Number(_) => false,
             PropValue::NumberOpt(opt) => opt.is_none(),
             PropValue::Bool(_) => false,
@@ -306,7 +306,7 @@ pub fn serialize_simfile(
 
     #[rustfmt::skip]
     let props = [
-        Prop::ssc_only_with_default(b"VERSION", DEFAULT_VERSION, PropValue::Version(summary.ssc_version)),
+        Prop::ssc_nonempty_only(b"VERSION", PropValue::Version(summary.ssc_version)),
         Prop::new_with_default(b"TITLE", DEFAULT_TITLE, PropValue::Str(&summary.title_str)),
         Prop::new(b"SUBTITLE", PropValue::Str(&summary.subtitle_str)),
         Prop::new_with_default(b"ARTIST", DEFAULT_ARTIST, PropValue::Str(&summary.artist_str)),

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -68,6 +68,7 @@ enum PropValue<'a> {
     Str(&'a str),
     StrOpt(Option<&'a str>),
     Bytes(&'a [u8]),
+    BytesOpt(Option<&'a [u8]>),
     NoteData(&'a [u8]),
     Version(f32),
     Number(f64),
@@ -89,6 +90,10 @@ impl<'a> PropValue<'a> {
                 Some(s) => PropValue::Str(s).serialize(out),
             },
             PropValue::Bytes(b) => write_all!(out, b),
+            PropValue::BytesOpt(opt) => match opt {
+                None => Ok(0),
+                Some(b) => PropValue::Bytes(*b).serialize(out),
+            },
             PropValue::NoteData(b) => Ok(write_all!(out, b"\n")? + write_all!(out, b)?),
             PropValue::Version(v) => write_all!(out, format_version(*v).as_bytes()),
             PropValue::Number(n) => write_all!(out, format_dot6_f64(*n).as_bytes()),
@@ -113,6 +118,9 @@ impl<'a> PropValue<'a> {
                     written_bytes += write_all!(out, &items[start..=comma])?;
                     written_bytes += write_all!(out, b"\n")?;
                     start = comma + 1;
+                    while start < items.len() && items[start].is_ascii_whitespace() {
+                        start += 1;
+                    }
                 }
 
                 written_bytes += write_all!(out, &items[start..])?;
@@ -152,6 +160,7 @@ impl<'a> PropValue<'a> {
             PropValue::Str(s) => s.is_empty(),
             PropValue::StrOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
             PropValue::Bytes(b) => b.is_empty(),
+            PropValue::BytesOpt(opt) => opt.as_ref().is_none_or(|b| b.is_empty()),
             PropValue::NoteData(_) => false,
             PropValue::Version(_) => false,
             PropValue::Number(_) => false,
@@ -352,7 +361,7 @@ pub fn serialize_simfile(
         Prop::new(b"SAMPLESTART", PropValue::Number(summary.sample_start)),
         Prop::new(b"SAMPLELENGTH", PropValue::Number(summary.sample_length)),
         Prop::new(b"SELECTABLE", PropValue::Bool(summary.selectable)),
-        Prop::nonempty_only(b"DISPLAYBPM", PropValue::Str(&summary.display_bpm_str)),
+        Prop::nonempty_only(b"DISPLAYBPM", PropValue::Bytes(&summary.display_bpm_str.as_bytes())), // Don't escape the ':' in ranges
         Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedList(&summary.normalized_bpms)),
         Prop::new(b"STOPS", PropValue::NormalizedList(&summary.normalized_stops)),
         Prop::ssc_only(b"DELAYS", PropValue::NormalizedList(&summary.normalized_delays)),
@@ -449,7 +458,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::own_timing_only(b"FAKES", PropValue::NormalizedListOpt(chart.chart_fakes.as_deref())),
         Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedListOpt(chart.chart_labels.as_deref())),
         Prop::nonempty_only(b"ATTACKS", PropValue::NormalizedListOpt(chart.chart_attacks.as_deref())),
-        Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrOpt(chart.chart_display_bpm.as_deref())),
+        Prop::nonempty_only(b"DISPLAYBPM", PropValue::BytesOpt(chart.chart_display_bpm.as_ref().map(|v| v.as_bytes()))),
         Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
         Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO
     ];

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -377,7 +377,7 @@ pub fn serialize_simfile(
         Prop::new(b"BGCHANGES", PropValue::NormalizedList(&summary.normalized_bgchanges)),
         Prop::nonempty_only(b"FGCHANGES", PropValue::NormalizedList(&summary.normalized_fgchanges)),
         Prop::new(b"KEYSOUNDS", PropValue::NormalizedList(&summary.normalized_keysounds)),
-        Prop::new(b"ATTACKS", PropValue::NormalizedList(&summary.normalized_attacks)),
+        Prop::new(b"ATTACKS", PropValue::Bytes(summary.normalized_attacks.as_bytes())), // Commas aren't always row separators
     ];
 
     for prop in props {
@@ -457,7 +457,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedListOpt(chart.chart_scrolls.as_deref())),
         Prop::own_timing_only(b"FAKES", PropValue::NormalizedListOpt(chart.chart_fakes.as_deref())),
         Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedListOpt(chart.chart_labels.as_deref())),
-        Prop::nonempty_only(b"ATTACKS", PropValue::NormalizedListOpt(chart.chart_attacks.as_deref())),
+        Prop::nonempty_only(b"ATTACKS", PropValue::BytesOpt(chart.chart_attacks.as_deref().map(|a| a.as_bytes()))),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::BytesOpt(chart.chart_display_bpm.as_ref().map(|v| v.as_bytes()))),
         Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
         Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -2,17 +2,16 @@ use std::io;
 
 use rssp_core::parse::extension_is_ssc;
 
-use crate::{SimfileSummary, stats::RADAR_CATEGORY_COUNT};
-
-const DEFAULT_BPMS: &str = "0.000=60.000";
-const DEFAULT_TIME_SIGNATURES: &str = "0.000000=4=4";
-const DEFAULT_SPEEDS: &str = "0.000000=1.000000=0.000000=0";
-const DEFAULT_SCROLLS: &str = "0.000000=1.000000";
-
-enum ValueWriter {
-    Plain,
-    List,
-}
+pub(crate) const DEFAULT_VERSION: &[u8] = b"0.83";
+pub(crate) const DEFAULT_TITLE: &[u8] = b"Untitled";
+pub(crate) const DEFAULT_ARTIST: &[u8] = b"Unknown artist";
+pub(crate) const DEFAULT_BPMS: &[u8] = b"0.000000=60.000000";
+pub(crate) const DEFAULT_TIME_SIGNATURES: &[u8] = b"0.000000=4=4";
+pub(crate) const DEFAULT_TICKCOUNTS: &[u8] = b"0.000000=4";
+pub(crate) const DEFAULT_COMBOS: &[u8] = b"0.000000=1";
+pub(crate) const DEFAULT_SPEEDS: &[u8] = b"0.000000=1.000000=0.000000=0";
+pub(crate) const DEFAULT_SCROLLS: &[u8] = b"0.000000=1.000000";
+pub(crate) const DEFAULT_LABELS: &[u8] = b"0.000000=Song Start";
 
 /// Call `write_all` and, on success, return the input's size in bytes
 macro_rules! write_all {
@@ -21,79 +20,47 @@ macro_rules! write_all {
     };
 }
 
-/// Unwrap `Some(String)` to `&str`, or `None` to `""`
-macro_rules! slice_or_default {
-    ($e: expr) => {
-        $e.as_deref().unwrap_or_default()
-    };
-    ($e: expr, $default: expr) => {
-        $e.as_deref().unwrap_or_else(|| $default)
-    };
-}
-
-fn write_prop(
-    key: &[u8],
-    value: &[u8],
-    writer: ValueWriter,
-    out: &mut dyn io::Write,
-) -> Result<usize, io::Error> {
+#[must_use]
+fn sm_escape(out: &mut dyn io::Write, bytes: &[u8]) -> io::Result<usize> {
     let mut written_bytes = 0;
-    written_bytes += write_all!(out, b"#")?;
-    written_bytes += write_all!(out, key)?;
-    written_bytes += write_all!(out, b":")?;
-    written_bytes += match writer {
-        ValueWriter::Plain => write_all!(out, value)?,
-        ValueWriter::List => write_comma_separated_list(out, value)?,
-    };
-    written_bytes += write_all!(out, b";\n")?;
-    Ok(written_bytes)
-}
+    let mut bytes_iter = bytes.iter().peekable();
 
-fn write_comma_separated_list(out: &mut dyn io::Write, value: &[u8]) -> io::Result<usize> {
-    let mut written_bytes = 0;
-    let mut start = 0;
-
-    while let Some(offset) = value[start..].iter().position(|&b| b == b',') {
-        let comma = start + offset;
-        written_bytes += write_all!(out, &value[start..=comma])?;
-        written_bytes += write_all!(out, b"\n")?;
-        start = comma + 1;
+    while let Some(&byte) = bytes_iter.next() {
+        if byte == b'/' && bytes_iter.peek().is_some_and(|&b| *b == b'/') {
+            written_bytes += write_all!(out, b"\\/\\/")?;
+            bytes_iter.next();
+            continue;
+        }
+        if byte == b'\\' || byte == b':' || byte == b';' {
+            written_bytes += write_all!(out, b"\\")?;
+        }
+        written_bytes += write_all!(out, &[byte])?;
     }
 
-    written_bytes += write_all!(out, &value[start..])?;
     Ok(written_bytes)
 }
 
-fn write_sm_chart_field(value: &str, out: &mut dyn io::Write) -> Result<usize, io::Error> {
-    let written_bytes =
-        write_all!(out, b"     ")? + out.write(value.as_bytes())? + write_all!(out, b":\n")?;
-    Ok(written_bytes)
-}
-
+#[must_use]
 #[inline(always)]
 fn format_version(ssc_version: f32) -> String {
     format!("{:.2}", ssc_version)
 }
 
+#[must_use]
 #[inline(always)]
 fn format_dot6_f64(value: f64) -> String {
     format!("{:.6}", value)
 }
 
+#[must_use]
 #[inline(always)]
 fn format_dot3_f32(value: f32) -> String {
     format!("{:.3}", value)
 }
 
+#[must_use]
 #[inline(always)]
-fn format_selectable(value: bool) -> String {
-    match value {
-        true => String::from("YES"),
-        false => String::from("NO"),
-    }
-}
-
-fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
+fn format_radar_values(radar_values: Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>) -> String {
     match radar_values {
         Some(radar_values) => radar_values
             .iter()
@@ -104,117 +71,470 @@ fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> Str
     }
 }
 
+enum ListItem<'a> {
+    Float(f64),
+    Int(i32),
+    Str(&'a str),
+}
+
+#[derive(Default)]
+enum PropValue<'a> {
+    #[default]
+    Empty,
+    Str(&'a str),
+    StrOpt(Option<&'a str>),
+    Bytes(&'a [u8]),
+    NoteData(&'a [u8]),
+    Version(f32),
+    Number(f64),
+    NumberOpt(Option<f64>),
+    Bool(bool),
+    NormalizedList(&'a str),
+    NormalizedListOpt(Option<&'a str>),
+    // TODO: decide if we actually need these.
+    // Currently only charts store timing fields like this and they're redundant with the normalized forms.
+    List(&'a [[Option<ListItem<'a>>; 4]]),
+    Pairs(&'a [(f64, f64)]),
+    TimeSignatures(&'a [(f64, i32, i32)]),
+    Labels(&'a [(f64, String)]),
+    TickCounts(&'a [(f64, i32)]),
+    Combos(&'a [(f64, i32, i32)]),
+    Speeds(&'a [(f64, f64, f64, i32)]),
+    RadarValues(Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>),
+}
+
+impl<'a> PropValue<'a> {
+    #[must_use]
+    fn serialize(&self, out: &mut dyn io::Write) -> io::Result<usize> {
+        use PropValue::*;
+
+        match self {
+            Empty => Ok(0),
+            Str(s) => sm_escape(out, s.as_bytes()),
+            StrOpt(opt) => match opt {
+                None => Ok(0),
+                Some(s) => Str(s).serialize(out),
+            },
+            Bytes(b) => write_all!(out, b),
+            NoteData(b) => Ok(write_all!(out, b"\n")? + write_all!(out, b)?),
+            Version(v) => write_all!(out, format_version(*v).as_bytes()),
+            Number(n) => write_all!(out, format_dot6_f64(*n).as_bytes()),
+            NumberOpt(opt) => match opt {
+                None => Ok(0),
+                Some(n) => Number(*n).serialize(out),
+            },
+            Bool(b) => {
+                if *b {
+                    write_all!(out, b"YES")
+                } else {
+                    write_all!(out, b"NO")
+                }
+            }
+            NormalizedList(items_str) => {
+                let items = items_str.as_bytes();
+                let mut written_bytes = 0;
+                let mut start = 0;
+
+                while let Some(offset) = items[start..].iter().position(|&b| b == b',') {
+                    let comma = start + offset;
+                    written_bytes += write_all!(out, &items[start..=comma])?;
+                    written_bytes += write_all!(out, b"\n")?;
+                    start = comma + 1;
+                }
+
+                written_bytes += write_all!(out, &items[start..])?;
+                Ok(written_bytes)
+            }
+            NormalizedListOpt(opt_items_str) => match opt_items_str {
+                None => Ok(0),
+                Some(items_str) => NormalizedList(items_str).serialize(out),
+            },
+            List(items) => {
+                let mut written_bytes = 0;
+                let mut first_row = true;
+
+                for row in *items {
+                    if !first_row {
+                        written_bytes += write_all!(out, b",\n")?;
+                    }
+                    let mut first_item = true;
+                    for item in row {
+                        if !first_item {
+                            written_bytes += write_all!(out, b"=")?;
+                        }
+                        written_bytes += match item {
+                            Some(ListItem::Float(f)) => {
+                                write_all!(out, format_dot6_f64(*f).as_bytes())?
+                            }
+                            Some(ListItem::Int(i)) => write_all!(out, i.to_string().as_bytes())?,
+                            Some(ListItem::Str(s)) => sm_escape(out, s.as_bytes())?,
+                            None => break,
+                        };
+                        first_item = false;
+                    }
+                    first_row = false;
+                }
+
+                Ok(written_bytes)
+            }
+            Pairs(rows) => List(
+                rows.iter()
+                    .map(|row| {
+                        [
+                            Some(ListItem::Float(row.0)),
+                            Some(ListItem::Float(row.1)),
+                            None,
+                            None,
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .serialize(out),
+            TimeSignatures(rows) => List(
+                rows.iter()
+                    .map(|row| {
+                        [
+                            Some(ListItem::Float(row.0)),
+                            Some(ListItem::Int(row.1)),
+                            Some(ListItem::Int(row.2)),
+                            None,
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .serialize(out),
+
+            Labels(rows) => List(
+                rows.iter()
+                    .map(|row| {
+                        [
+                            Some(ListItem::Float(row.0)),
+                            Some(ListItem::Str(&row.1)),
+                            None,
+                            None,
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .serialize(out),
+            TickCounts(rows) => List(
+                rows.iter()
+                    .map(|row| {
+                        [
+                            Some(ListItem::Float(row.0)),
+                            Some(ListItem::Int(row.1)),
+                            None,
+                            None,
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .serialize(out),
+            Combos(rows) => List(
+                rows.iter()
+                    .map(|row| {
+                        [
+                            Some(ListItem::Float(row.0)),
+                            Some(ListItem::Int(row.1)),
+                            None,
+                            None,
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .serialize(out),
+            Speeds(rows) => List(
+                rows.iter()
+                    .map(|row| {
+                        [
+                            Some(ListItem::Float(row.0)),
+                            Some(ListItem::Float(row.1)),
+                            Some(ListItem::Float(row.2)),
+                            Some(ListItem::Int(row.3)),
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .serialize(out),
+            RadarValues(rv) => match rv {
+                Some(values) => {
+                    let mut written_bytes = 0;
+                    let mut first_item = true;
+
+                    for value in values {
+                        if !first_item {
+                            written_bytes += write_all!(out, b",")?;
+                        }
+                        written_bytes += write_all!(out, format_dot3_f32(*value).as_bytes())?;
+                        first_item = false;
+                    }
+
+                    Ok(written_bytes)
+                }
+                None => Ok(0),
+            },
+        }
+    }
+
+    #[must_use]
+    fn is_empty(&self) -> bool {
+        use PropValue::*;
+        match self {
+            Empty => true,
+            Str(s) => s.is_empty(),
+            StrOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
+            Bytes(b) => b.is_empty(),
+            NoteData(_) => false,
+            Version(_) => false,
+            Number(_) => false,
+            NumberOpt(opt) => opt.is_none(),
+            Bool(_) => false,
+            NormalizedList(s) => s.is_empty(),
+            NormalizedListOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
+            List(rows) => rows.is_empty(),
+            Pairs(rows) => rows.is_empty(),
+            TimeSignatures(rows) => rows.is_empty(),
+            Labels(rows) => rows.is_empty(),
+            TickCounts(rows) => rows.is_empty(),
+            Combos(rows) => rows.is_empty(),
+            Speeds(rows) => rows.is_empty(),
+            RadarValues(rv) => rv.is_none(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Prop<'a> {
+    key: &'a [u8],
+    value: PropValue<'a>,
+    default_value: Option<&'a [u8]>,
+    ssc_only: bool,
+    nonempty_value_only: bool,
+    own_timing_only: bool,
+}
+
+impl<'a> Prop<'a> {
+    #[must_use]
+    #[inline(always)]
+    fn new(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn new_with_default(key: &'a [u8], default: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            default_value: Some(default),
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn ssc_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            ssc_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn ssc_nonempty_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            ssc_only: true,
+            nonempty_value_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn ssc_only_with_default(key: &'a [u8], default: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            default_value: Some(default),
+            ssc_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn nonempty_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            nonempty_value_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn own_timing_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            own_timing_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn own_timing_only_with_default(
+        key: &'a [u8],
+        default: &'a [u8],
+        value: PropValue<'a>,
+    ) -> Prop<'a> {
+        Prop {
+            key,
+            value,
+            default_value: Some(default),
+            own_timing_only: true,
+            ..Default::default()
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn start_prop(out: &mut dyn io::Write, key: &[u8]) -> io::Result<usize> {
+        let mut written_bytes = 0;
+        written_bytes += write_all!(out, b"#")?;
+        written_bytes += write_all!(out, key)?;
+        written_bytes += write_all!(out, b":")?;
+        Ok(written_bytes)
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn end_prop(out: &mut dyn io::Write) -> io::Result<usize> {
+        Ok(write_all!(out, b";\n")?)
+    }
+
+    #[must_use]
+    fn serialize(self, ssc: bool, own_timing: bool, out: &mut dyn io::Write) -> io::Result<usize> {
+        if self.ssc_only && !ssc {
+            Ok(0)
+        } else if self.nonempty_value_only && self.value.is_empty() {
+            Ok(0)
+        } else if self.own_timing_only && !own_timing {
+            Ok(0)
+        } else {
+            let value = match (self.default_value, self.value.is_empty()) {
+                (Some(default), true) => PropValue::Bytes(default),
+                _ => self.value,
+            };
+            let mut written_bytes = 0;
+            written_bytes += Prop::start_prop(out, self.key)?;
+            written_bytes += value.serialize(out)?;
+            written_bytes += Prop::end_prop(out)?;
+            Ok(written_bytes)
+        }
+    }
+}
+
+#[must_use]
 pub fn serialize_simfile(
-    summary: &SimfileSummary,
+    summary: &crate::SimfileSummary,
     extension: &str,
     out: &mut dyn io::Write,
 ) -> io::Result<usize> {
-    use ValueWriter::*;
-
     let ssc = extension_is_ssc(extension)?;
-
     let mut written_bytes = 0;
 
-    let formatted_version = format_version(summary.ssc_version);
-    let formatted_offset = format_dot6_f64(summary.offset);
-    let formatted_sample_start = format_dot6_f64(summary.sample_start);
-    let formatted_sample_length = format_dot6_f64(summary.sample_length);
-    let formatted_selectable = format_selectable(summary.selectable);
-
-    // (key, value, is_included, value_writer)
-    let properties: Vec<(&[u8], &str, bool, ValueWriter)> = vec![
-        (b"VERSION", &formatted_version, ssc, Plain),
-        (b"TITLE", &summary.title_str, true, Plain),
-        (b"SUBTITLE", &summary.subtitle_str, true, Plain),
-        (b"ARTIST", &summary.artist_str, true, Plain),
-        (b"TITLETRANSLIT", &summary.titletranslit_str, true, Plain),
-        (
-            b"SUBTITLETRANSLIT",
-            &summary.subtitletranslit_str,
-            true,
-            Plain,
-        ),
-        (b"ARTISTTRANSLIT", &summary.artisttranslit_str, true, Plain),
-        (b"GENRE", &summary.genre_str, true, Plain),
-        (b"ORIGIN", &summary.origin_str, ssc, Plain),
-        (b"CREDIT", &summary.credit_str, true, Plain),
-        (b"BANNER", &summary.banner_path, true, Plain),
-        (b"BACKGROUND", &summary.background_path, true, Plain),
-        (b"PREVIEWVID", &summary.previewvid_path, ssc, Plain),
-        (b"JACKET", &summary.jacket_path, ssc, Plain),
-        (b"CDIMAGE", &summary.cdimage_path, ssc, Plain),
-        (b"DISCIMAGE", &summary.discimage_path, ssc, Plain),
-        (b"LYRICSPATH", &summary.lyrics_path, true, Plain),
-        (b"CDTITLE", &summary.cdtitle_path, true, Plain),
-        (b"MUSIC", &summary.music_path, true, Plain),
-        (b"OFFSET", &formatted_offset, true, Plain),
-        (b"SAMPLESTART", &formatted_sample_start, true, Plain),
-        (b"SAMPLELENGTH", &formatted_sample_length, true, Plain),
-        (b"SELECTABLE", &formatted_selectable, true, Plain),
-        (
-            b"DISPLAYBPM",
-            &summary.display_bpm_str,
-            !summary.display_bpm_str.is_empty(),
-            Plain,
-        ),
-        (b"BPMS", &summary.normalized_bpms, true, List),
-        (b"STOPS", &summary.normalized_stops, true, List),
-        (b"DELAYS", &summary.normalized_delays, ssc, List),
-        (b"WARPS", &summary.normalized_warps, ssc, List),
-        (
-            b"TIMESIGNATURES",
-            &summary.normalized_time_signatures,
-            ssc,
-            List,
-        ),
-        (b"TICKCOUNTS", &summary.normalized_tickcounts, ssc, List),
-        (b"COMBOS", &summary.normalized_combos, ssc, List),
-        (b"SPEEDS", &summary.normalized_speeds, ssc, List),
-        (b"SCROLLS", &summary.normalized_scrolls, ssc, List),
-        (b"FAKES", &summary.normalized_fakes, ssc, List),
-        (b"LABELS", &summary.normalized_labels, ssc, List),
-        (b"BGCHANGES", &summary.normalized_bgchanges, true, List),
-        (
-            b"FGCHANGES",
-            &summary.normalized_fgchanges,
-            !summary.normalized_fgchanges.is_empty(),
-            List,
-        ),
-        (b"KEYSOUNDS", &summary.normalized_keysounds, true, List),
-        // TODO: make sure the implementation for this meshes well with the original ATTACKS implementation
-        (b"ATTACKS", &summary.normalized_attacks, true, List),
+    #[rustfmt::skip]
+    let props = [
+        Prop::ssc_only_with_default(b"VERSION", DEFAULT_VERSION, PropValue::Version(summary.ssc_version)),
+        Prop::new_with_default(b"TITLE", DEFAULT_TITLE, PropValue::Str(&summary.title_str)),
+        Prop::new(b"SUBTITLE", PropValue::Str(&summary.subtitle_str)),
+        Prop::new_with_default(b"ARTIST", DEFAULT_ARTIST, PropValue::Str(&summary.artist_str)),
+        Prop::new(b"TITLETRANSLIT", PropValue::Str(&summary.titletranslit_str)),
+        Prop::new(b"SUBTITLETRANSLIT", PropValue::Str(&summary.subtitletranslit_str)),
+        Prop::new(b"ARTISTTRANSLIT", PropValue::Str(&summary.artisttranslit_str)),
+        Prop::new(b"GENRE", PropValue::Str(&summary.genre_str)),
+        Prop::ssc_only(b"ORIGIN", PropValue::Str(&summary.origin_str)),
+        Prop::new(b"CREDIT", PropValue::Str(&summary.credit_str)),
+        Prop::new(b"BANNER", PropValue::Str(&summary.banner_path)),
+        Prop::new(b"BACKGROUND", PropValue::Str(&summary.background_path)),
+        Prop::ssc_only(b"PREVIEWVID", PropValue::Str(&summary.previewvid_path)),
+        Prop::ssc_only(b"JACKET", PropValue::Str(&summary.jacket_path)),
+        Prop::ssc_only(b"CDIMAGE", PropValue::Str(&summary.cdimage_path)),
+        Prop::ssc_only(b"DISCIMAGE", PropValue::Str(&summary.discimage_path)),
+        Prop::new(b"LYRICSPATH", PropValue::Str(&summary.lyrics_path)),
+        Prop::new(b"CDTITLE", PropValue::Str(&summary.cdtitle_path)),
+        Prop::new(b"MUSIC", PropValue::Str(&summary.music_path)),
+        Prop::new(b"OFFSET", PropValue::Number(summary.offset)),
+        Prop::new(b"SAMPLESTART", PropValue::Number(summary.sample_start)),
+        Prop::new(b"SAMPLELENGTH", PropValue::Number(summary.sample_length)),
+        Prop::new(b"SELECTABLE", PropValue::Bool(summary.selectable)),
+        Prop::nonempty_only(b"DISPLAYBPM", PropValue::Str(&summary.display_bpm_str)),
+        Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedList(&summary.normalized_bpms)),
+        Prop::new(b"STOPS", PropValue::NormalizedList(&summary.normalized_stops)),
+        Prop::ssc_only(b"DELAYS", PropValue::NormalizedList(&summary.normalized_delays)),
+        Prop::ssc_only(b"WARPS", PropValue::NormalizedList(&summary.normalized_warps)),
+        Prop::ssc_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::NormalizedList(&summary.normalized_time_signatures)),
+        Prop::ssc_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::NormalizedList(&summary.normalized_tickcounts)),
+        Prop::ssc_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::NormalizedList(&summary.normalized_combos)),
+        Prop::ssc_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::NormalizedList(&summary.normalized_speeds)),
+        Prop::ssc_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedList(&summary.normalized_scrolls)),
+        Prop::ssc_only(b"FAKES", PropValue::NormalizedList(&summary.normalized_fakes)),
+        Prop::ssc_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedList(&summary.normalized_labels)),
+        Prop::ssc_nonempty_only(b"LASTSECONDHINT", PropValue::NumberOpt(None)), // TODO: add SimfileSummary.last_second_hint
+        Prop::new(b"BGCHANGES", PropValue::NormalizedList(&summary.normalized_bgchanges)),
+        Prop::nonempty_only(b"FGCHANGES", PropValue::NormalizedList(&summary.normalized_fgchanges)),
+        Prop::new(b"KEYSOUNDS", PropValue::NormalizedList(&summary.normalized_keysounds)),
+        Prop::new(b"ATTACKS", PropValue::NormalizedList(&summary.normalized_attacks)),
     ];
 
-    for (key, value, is_included, value_writer) in properties {
-        if is_included {
-            written_bytes += write_prop(key, value.as_bytes(), value_writer, out)?;
-        }
+    for prop in props {
+        written_bytes += prop.serialize(ssc, false, out)?;
     }
 
     written_bytes += write_all!(out, b"\n")?;
 
-    match ssc {
-        true => {
-            for chart in &summary.charts {
-                written_bytes += serialize_ssc_chart(out, chart)?;
-                written_bytes += write_all!(out, b"\n")?;
-            }
-        }
-        false => {
-            for chart in &summary.charts {
-                written_bytes += serialize_sm_chart(out, chart)?;
-                written_bytes += write_all!(out, b"\n")?;
-            }
-        }
+    for chart in &summary.charts {
+        written_bytes += if ssc {
+            serialize_ssc_chart(out, chart)
+        } else {
+            serialize_sm_chart(out, chart)
+        }?;
+        written_bytes += write_all!(out, b"\n")?;
     }
 
     Ok(written_bytes)
 }
 
-fn serialize_sm_chart(
-    out: &mut dyn io::Write,
-    chart: &crate::ChartSummary,
-) -> Result<usize, io::Error> {
+#[must_use]
+#[inline(always)]
+fn write_sm_chart_field(value: &str, out: &mut dyn io::Write) -> io::Result<usize> {
+    let mut written_bytes = 0;
+    written_bytes += write_all!(out, b"     ")?;
+    written_bytes += out.write(value.as_bytes())?;
+    written_bytes += write_all!(out, b":\n")?;
+    Ok(written_bytes)
+}
+
+#[must_use]
+fn serialize_sm_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> io::Result<usize> {
     let mut written_bytes = 0;
     written_bytes += write_all!(out, b"#NOTES:\n")?;
     written_bytes += write_sm_chart_field(&chart.step_type_str, out)?;
@@ -227,106 +547,42 @@ fn serialize_sm_chart(
     Ok(written_bytes)
 }
 
-fn serialize_ssc_chart(
-    out: &mut dyn io::Write,
-    chart: &crate::ChartSummary,
-) -> Result<usize, io::Error> {
+#[must_use]
+fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> io::Result<usize> {
     let mut written_bytes = 0;
-    let formatted_radar_values = format_radar_values(chart.cached_radar_values);
-    let chart_properties: Vec<(&[u8], &str)> = vec![
-        (b"NOTEDATA", ""),
-        (b"CHARTNAME", &chart.chart_name_str),
-        (b"STEPSTYPE", &chart.step_type_str),
-        (b"DESCRIPTION", &chart.description_str),
-        (b"CHARTSTYLE", &chart.chart_style_str),
-        (b"DIFFICULTY", &chart.difficulty_str),
-        (b"METER", &chart.rating_str),
-        (b"RADARVALUES", &formatted_radar_values),
-        (b"CREDIT", &chart.step_artist_str),
+
+    #[rustfmt::skip]
+    let props = [
+        Prop::new(b"NOTEDATA", PropValue::Empty),
+        Prop::new(b"CHARTNAME", PropValue::Str(&chart.chart_name_str)),
+        Prop::new_with_default(b"STEPSTYPE", b"dance-single", PropValue::Str(&chart.step_type_str)),
+        Prop::new(b"DESCRIPTION", PropValue::Str(&chart.description_str)),
+        Prop::new(b"CHARTSTYLE", PropValue::Str(&chart.chart_style_str)),
+        Prop::new_with_default(b"DIFFICULTY", b"Beginner", PropValue::Str(&chart.difficulty_str)),
+        Prop::new_with_default(b"METER", b"1", PropValue::Str(&chart.rating_str)),
+        Prop::nonempty_only(b"MUSIC", PropValue::Str(&chart.music_path)), // TODO
+        Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values)),
+        Prop::new(b"CREDIT", PropValue::Str(&chart.step_artist_str)),
+        Prop::own_timing_only(b"OFFSET", PropValue::Number(chart.chart_offset_seconds)),
+        Prop::own_timing_only_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedListOpt(chart.chart_bpms.as_deref())),
+        Prop::own_timing_only(b"STOPS", PropValue::NormalizedListOpt(chart.chart_stops.as_deref())),
+        Prop::own_timing_only(b"DELAYS", PropValue::NormalizedListOpt(chart.chart_delays.as_deref())),
+        Prop::own_timing_only(b"WARPS", PropValue::NormalizedListOpt(chart.chart_warps.as_deref())),
+        Prop::own_timing_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::NormalizedListOpt(chart.chart_time_signatures.as_deref())),
+        Prop::own_timing_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::NormalizedListOpt(chart.chart_tickcounts.as_deref())),
+        Prop::own_timing_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::NormalizedListOpt(chart.chart_combos.as_deref())),
+        Prop::own_timing_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::NormalizedListOpt(chart.chart_speeds.as_deref())),
+        Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedListOpt(chart.chart_scrolls.as_deref())),
+        Prop::own_timing_only(b"FAKES", PropValue::NormalizedListOpt(chart.chart_fakes.as_deref())),
+        Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedListOpt(chart.chart_labels.as_deref())),
+        Prop::nonempty_only(b"ATTACKS", PropValue::NormalizedListOpt(chart.chart_attacks.as_deref())),
+        Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrOpt(chart.chart_display_bpm.as_deref())),
+        Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
+        Prop::nonempty_only(b"NOTES2", PropValue::Empty), // TODO
     ];
 
-    for property in chart_properties {
-        written_bytes += write_prop(property.0, property.1.as_bytes(), ValueWriter::Plain, out)?;
-    }
-
-    if chart.chart_has_own_timing {
-        written_bytes += serialize_ssc_chart_timing_fields(out, chart)?;
-    }
-
-    written_bytes += write_all!(out, b"#NOTES:\n")?;
-    written_bytes += write_all!(out, &chart.minimized_note_data)?;
-    written_bytes += write_all!(out, b";\n")?;
-
-    Ok(written_bytes)
-}
-
-fn serialize_ssc_chart_timing_fields(
-    out: &mut dyn io::Write,
-    chart: &crate::ChartSummary,
-) -> Result<usize, io::Error> {
-    use ValueWriter::*;
-
-    let mut written_bytes = 0;
-    let formatted_chart_offset = format_dot6_f64(chart.chart_offset_seconds);
-    let chart_timing_properties: Vec<(&[u8], &str, ValueWriter, bool)> = vec![
-        (b"OFFSET", &formatted_chart_offset, Plain, true),
-        (
-            b"BPMS",
-            slice_or_default!(chart.chart_bpms, DEFAULT_BPMS),
-            List,
-            true,
-        ),
-        (b"STOPS", slice_or_default!(chart.chart_stops), List, true),
-        (b"DELAYS", slice_or_default!(chart.chart_delays), List, true),
-        (b"WARPS", slice_or_default!(chart.chart_warps), List, true),
-        (
-            b"TIMESIGNATURES",
-            slice_or_default!(chart.chart_time_signatures, DEFAULT_TIME_SIGNATURES),
-            List,
-            true,
-        ),
-        (
-            b"TICKCOUNTS",
-            slice_or_default!(chart.chart_tickcounts),
-            List,
-            true,
-        ),
-        (b"COMBOS", slice_or_default!(chart.chart_combos), List, true),
-        (
-            b"SPEEDS",
-            slice_or_default!(chart.chart_speeds, DEFAULT_SPEEDS),
-            List,
-            true,
-        ),
-        (
-            b"SCROLLS",
-            slice_or_default!(chart.chart_scrolls, DEFAULT_SCROLLS),
-            List,
-            true,
-        ),
-        (b"FAKES", slice_or_default!(chart.chart_fakes), List, true),
-        (b"LABELS", slice_or_default!(chart.chart_labels), List, true),
-        (
-            b"ATTACKS",
-            slice_or_default!(chart.chart_attacks),
-            List,
-            !chart.chart_attacks.as_ref().is_none_or(|v| v.is_empty()),
-        ),
-        (
-            b"DISPLAYBPM",
-            slice_or_default!(chart.chart_display_bpm),
-            Plain,
-            !chart
-                .chart_display_bpm
-                .as_ref()
-                .is_none_or(|v| v.is_empty()),
-        ),
-    ];
-
-    for (key, value, value_writer, is_included) in chart_timing_properties {
-        if is_included {
-            written_bytes += write_prop(key, value.as_bytes(), value_writer, out)?;
-        }
+    for prop in props {
+        written_bytes += prop.serialize(true, chart.chart_has_own_timing, out)?;
     }
 
     Ok(written_bytes)
@@ -535,7 +791,7 @@ mod tests {
         Ok(())
     }
 
-    fn simfile_summary_with_all_fields() -> crate::SimfileSummary {
+    fn simfile_summary_with_all_fields(include_nonempty: bool) -> crate::SimfileSummary {
         crate::SimfileSummary {
             title_str: String::from("Title"),
             subtitle_str: String::from("Subtitle"),
@@ -565,20 +821,21 @@ mod tests {
             cdtitle_path: String::from("cdtitle.png"),
             jacket_path: String::from("jacket.png"),
             music_path: String::from("music.ogg"),
-            display_bpm_str: String::from("150"),
+            display_bpm_str: String::from("150"), // TODO include_nonempty
             sample_start: 10.0,
             sample_length: 16.0,
             origin_str: String::from("Origin"),
             credit_str: String::from("Credit"),
             normalized_bgchanges: Default::default(), // TODO
-            normalized_fgchanges: Default::default(), // TODO
+            normalized_fgchanges: Default::default(), // TODO include_nonempty
             normalized_keysounds: Default::default(), // TODO
-            normalized_attacks: Default::default(),   // TODO
+            normalized_attacks: Default::default(),
             previewvid_path: String::from("previewvid.mov"),
             cdimage_path: String::from("cdimage.png"),
             discimage_path: String::from("discimage.png"),
             lyrics_path: String::from("lyrics.lrc"),
             selectable: true,
+            // last_second_hint: Some(120.0), // TODO include_nonempty
 
             // To be populated by the test
             charts: vec![],

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -489,6 +489,68 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn serialize_simfile_with_sm() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields();
+        summary.charts.push(chart_summary_with_all_fields(false));
+        summary.charts.push(chart_summary_with_all_fields(true));
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+            super::serialize_simfile(&summary, "sm", &mut cursor)?;
+            cursor.get_ref()
+        };
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        let expected = "#TITLE:Title;\n\
+        #SUBTITLE:Subtitle;\n\
+        #ARTIST:Artist;\n\
+        #TITLETRANSLIT:Title translit;\n\
+        #SUBTITLETRANSLIT:Subtitle translit;\n\
+        #ARTISTTRANSLIT:Artist translit;\n\
+        #GENRE:Genre;\n\
+        #ORIGIN:;\n\
+        #CREDIT:;\n\
+        #BANNER:banner.png;\n\
+        #BACKGROUND:background.png;\n\
+        #LYRICSPATH:;\n\
+        #CDTITLE:cdtitle.png;\n\
+        #MUSIC:music.ogg;\n\
+        #OFFSET:0.123000;\n\
+        #SAMPLESTART:10.000000;\n\
+        #SAMPLELENGTH:16.000000;\n\
+        #SELECTABLE:YES;\n\
+        #DISPLAYBPM:150;\n\
+        #BPMS:0.000=120.000,\n\
+        16.000=240.000,\n\
+        48.000=120.000;\n\
+        #STOPS:1.000=1.250,\n\
+        1.500=1.750;\n\
+        #BGCHANGES:;\n\
+        #KEYSOUNDS:;\n\
+        #ATTACKS:;\n\
+        \n\
+        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        ;\n\
+        \n\
+        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        ;\n\
+        \n";
+
+        assert_eq!(expected, output);
+
+        Ok(())
+    }
+
     fn simfile_summary_with_all_fields() -> crate::SimfileSummary {
         crate::SimfileSummary {
             title_str: String::from("Title"),

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -364,7 +364,7 @@ pub fn serialize_simfile(
         Prop::ssc_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedList(&summary.normalized_scrolls)),
         Prop::ssc_only(b"FAKES", PropValue::NormalizedList(&summary.normalized_fakes)),
         Prop::ssc_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedList(&summary.normalized_labels)),
-        Prop::ssc_nonempty_only(b"LASTSECONDHINT", PropValue::NumberOpt(None)), // TODO: add SimfileSummary.last_second_hint
+        Prop::ssc_nonempty_only(b"LASTSECONDHINT", PropValue::NumberOpt(summary.last_second_hint)),
         Prop::new(b"BGCHANGES", PropValue::NormalizedList(&summary.normalized_bgchanges)),
         Prop::nonempty_only(b"FGCHANGES", PropValue::NormalizedList(&summary.normalized_fgchanges)),
         Prop::new(b"KEYSOUNDS", PropValue::NormalizedList(&summary.normalized_keysounds)),
@@ -1131,7 +1131,7 @@ mod tests {
             discimage_path: String::from("discimage.png"),
             lyrics_path: String::from("lyrics.lrc"),
             selectable: true,
-            // last_second_hint: include_nonempty.then(|| 120.0), // TODO
+            last_second_hint: include_nonempty.then(|| 120.0),
 
             // To be populated by the test
             charts: vec![],

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -194,88 +194,56 @@ impl<'a> Prop<'a> {
         }
     }
 
-    #[must_use]
-    #[inline(always)]
     fn new_with_default(key: &'a [u8], default: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            default_value: Some(default),
-            ..Default::default()
-        }
+        let mut prop = Prop::new(key, value);
+        prop.default_value = Some(default);
+        prop
     }
 
     #[must_use]
-    #[inline(always)]
     fn ssc_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            ssc_only: true,
-            ..Default::default()
-        }
+        let mut prop = Prop::new(key, value);
+        prop.ssc_only = true;
+        prop
     }
 
     #[must_use]
-    #[inline(always)]
     fn ssc_nonempty_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            ssc_only: true,
-            nonempty_value_only: true,
-            ..Default::default()
-        }
+        let mut prop = Prop::ssc_only(key, value);
+        prop.nonempty_value_only = true;
+        prop
     }
 
     #[must_use]
-    #[inline(always)]
     fn ssc_only_with_default(key: &'a [u8], default: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            default_value: Some(default),
-            ssc_only: true,
-            ..Default::default()
-        }
+        let mut prop = Prop::ssc_only(key, value);
+        prop.default_value = Some(default);
+        prop
     }
 
     #[must_use]
-    #[inline(always)]
     fn nonempty_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            nonempty_value_only: true,
-            ..Default::default()
-        }
+        let mut prop = Prop::new(key, value);
+        prop.nonempty_value_only = true;
+        prop
     }
 
     #[must_use]
-    #[inline(always)]
     fn own_timing_only(key: &'a [u8], value: PropValue<'a>) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            own_timing_only: true,
-            ..Default::default()
-        }
+        let mut prop = Prop::new(key, value);
+        prop.own_timing_only = true;
+        prop
     }
 
     #[must_use]
-    #[inline(always)]
     fn own_timing_only_with_default(
         key: &'a [u8],
         default: &'a [u8],
         value: PropValue<'a>,
     ) -> Prop<'a> {
-        Prop {
-            key,
-            value,
-            default_value: Some(default),
-            own_timing_only: true,
-            ..Default::default()
-        }
+        let mut prop = Prop::own_timing_only(key, value);
+        prop.default_value = Some(default);
+        prop
     }
 
     #[must_use]

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -431,6 +431,10 @@ mod tests {
             #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #NOTES:\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            0000\n\
             ;\n\
             \n\
             #NOTEDATA:;\n\
@@ -473,6 +477,10 @@ mod tests {
             16.000=Speedup;\n\
             #DISPLAYBPM:150;\n\
             #NOTES:\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            0000\n\
             ;\n\
             \n";
 
@@ -543,7 +551,7 @@ mod tests {
                 0.130, 0.140,
             ]),
             tech_notation_str: String::from("BR FS XO"),
-            minimized_note_data: Default::default(), // TODO
+            minimized_note_data: b"0000\n0000\n0000\n0000\n".to_vec(), // TODO
 
             // Timing fields
             chart_has_own_timing: has_own_timing,

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -70,15 +70,15 @@ fn format_dot6_f64(value: f64) -> String {
 }
 
 #[inline(always)]
-fn format_dot6_f32(value: f32) -> String {
-    format!("{:.6}", value)
+fn format_dot3_f32(value: f32) -> String {
+    format!("{:.3}", value)
 }
 
 fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
     match radar_values {
         Some(radar_values) => radar_values
             .iter()
-            .map(|&f| format_dot6_f32(f))
+            .map(|&f| format_dot3_f32(f))
             .collect::<Vec<String>>()
             .join(","),
         None => String::from(""),
@@ -428,7 +428,7 @@ mod tests {
             #CHARTSTYLE:;\n\
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
-            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
+            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
             #CREDIT:Step artist;\n\
             #NOTES:\n\
             0000\n\
@@ -444,7 +444,7 @@ mod tests {
             #CHARTSTYLE:;\n\
             #DIFFICULTY:Challenge;\n\
             #METER:17;\n\
-            #RADARVALUES:0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
+            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
             #BPMS:0.000=120.000,\n\

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -1,0 +1,191 @@
+use std::io;
+
+use rssp_core::parse::extension_is_ssc;
+
+use crate::{SimfileSummary, stats::RADAR_CATEGORY_COUNT};
+
+const DEFAULT_BPMS: &str = "0.000=60.000";
+const DEFAULT_TIME_SIGNATURES: &str = "0.000000=4=4";
+const DEFAULT_SPEEDS: &str = "0.000000=1.000000=0.000000=0";
+const DEFAULT_SCROLLS: &str = "0.000000=1.000000";
+
+fn serialize_prop(key: &[u8], value: &[u8], out: &mut dyn io::Write) -> Result<usize, io::Error> {
+    let written_bytes = out.write(b"#")?
+        + out.write(key)?
+        + out.write(b":")?
+        + out.write(value)?
+        + out.write(b";\n")?;
+    Ok(written_bytes)
+}
+
+fn serialize_sm_chart_field(value: &str, out: &mut dyn io::Write) -> Result<usize, io::Error> {
+    let written_bytes = out.write(b"     ")? + out.write(value.as_bytes())? + out.write(b":\n")?;
+    Ok(written_bytes)
+}
+
+fn format_version(ssc_version: f32) -> String {
+    format!("{:.2}", ssc_version)
+}
+
+fn format_f64(value: f64) -> String {
+    format!("{:.6}", value)
+}
+
+fn format_f32(value: f32) -> String {
+    format!("{:.3}", value)
+}
+
+fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
+    match radar_values {
+        Some(radar_values) => radar_values
+            .iter()
+            .map(|&f| format_f32(f))
+            .collect::<Vec<String>>()
+            .join(":"),
+        None => String::from(""),
+    }
+}
+
+pub fn serialize_simfile(
+    summary: SimfileSummary,
+    extension: &str,
+    out: &mut dyn io::Write,
+) -> io::Result<usize> {
+    let ssc = extension_is_ssc(extension)?;
+
+    let mut written_bytes = 0;
+
+    {
+        let properties: Vec<(&[u8], String, bool)> = vec![
+            (b"VERSION", format_version(summary.ssc_version), ssc),
+            (b"TITLE", summary.title_str, true),
+            (b"SUBTITLE", summary.subtitle_str, true),
+            (b"ARTIST", summary.artist_str, true),
+            (b"TITLETRANSLIT", summary.titletranslit_str, true),
+            (b"SUBTITLETRANSLIT", summary.subtitletranslit_str, true),
+            (b"ARTISTTRANSLIT", summary.artisttranslit_str, true),
+            (b"GENRE", summary.genre_str, true),
+            (b"OFFSET", format_f64(summary.offset), true),
+            // TODO: store attacks on SimfileSummary
+            (b"ATTACKS", String::from(""), true),
+            (b"BPMS", summary.normalized_bpms, true),
+            (b"STOPS", summary.normalized_stops, true),
+            (b"DELAYS", summary.normalized_delays, true),
+            (b"TIMESIGNATURES", summary.normalized_time_signatures, true),
+            (b"TICKCOUNTS", summary.normalized_tickcounts, true),
+            (b"BANNER", summary.banner_path, true),
+            (b"BACKGROUND", summary.background_path, true),
+            (b"CDTITLE", summary.cdtitle_path, true),
+            (b"JACKET", summary.jacket_path, true),
+            (b"MUSIC", summary.music_path, true),
+            (b"SAMPLESTART", format_f64(summary.sample_start), true),
+            (b"SAMPLELENGTH", format_f64(summary.sample_length), true),
+            (b"DISPLAYBPM", summary.display_bpm_str, true),
+            (b"FAKES", summary.normalized_fakes, ssc),
+            (b"WARPS", summary.normalized_warps, ssc),
+            (b"SPEEDS", summary.normalized_speeds, ssc),
+            (b"SCROLLS", summary.normalized_scrolls, ssc),
+            (b"LABELS", summary.normalized_labels, ssc),
+            (b"COMBOS", summary.normalized_combos, ssc),
+        ];
+
+        for property in properties {
+            if property.2 {
+                written_bytes += serialize_prop(property.0, property.1.as_bytes(), out)?;
+            }
+        }
+    }
+
+    match ssc {
+        true => {
+            for chart in summary.charts {
+                {
+                    let chart_properties: Vec<(&[u8], String)> = vec![
+                        (b"NOTEDATA", String::from("")),
+                        (b"CHARTNAME", chart.chart_name_str),
+                        (b"STEPSTYPE", chart.step_type_str),
+                        (b"DESCRIPTION", chart.description_str),
+                        // TODO: store chart_style_str on ChartSummary
+                        (b"CHARTSTYLE", String::from("")),
+                        (b"DIFFICULTY", chart.difficulty_str),
+                        (b"METER", chart.rating_str),
+                        (
+                            b"RADARVALUES",
+                            format_radar_values(chart.cached_radar_values),
+                        ),
+                        (b"CREDIT", chart.step_artist_str),
+                    ];
+
+                    for property in chart_properties {
+                        written_bytes += serialize_prop(property.0, property.1.as_bytes(), out)?;
+                    }
+                }
+
+                if chart.chart_has_own_timing {
+                    let chart_timing_properties: Vec<(&[u8], String)> = vec![
+                        (b"OFFSET", format_f64(chart.chart_offset_seconds)),
+                        (
+                            b"BPMS",
+                            chart.chart_bpms.unwrap_or(String::from(DEFAULT_BPMS)),
+                        ),
+                        (b"STOPS", chart.chart_stops.unwrap_or(String::from(""))),
+                        (b"DELAYS", chart.chart_delays.unwrap_or(String::from(""))),
+                        (b"WARPS", chart.chart_warps.unwrap_or(String::from(""))),
+                        (
+                            b"TIMESIGNATURES",
+                            chart
+                                .chart_time_signatures
+                                .unwrap_or(String::from(DEFAULT_TIME_SIGNATURES)),
+                        ),
+                        (
+                            b"TICKCOUNTS",
+                            chart.chart_tickcounts.unwrap_or(String::from("")),
+                        ),
+                        (b"COMBOS", chart.chart_combos.unwrap_or(String::from(""))),
+                        (
+                            b"SPEEDS",
+                            chart.chart_speeds.unwrap_or(String::from(DEFAULT_SPEEDS)),
+                        ),
+                        (
+                            b"SCROLLS",
+                            chart.chart_scrolls.unwrap_or(String::from(DEFAULT_SCROLLS)),
+                        ),
+                        (b"FAKES", chart.chart_fakes.unwrap_or(String::from(""))),
+                        (b"LABELS", chart.chart_labels.unwrap_or(String::from(""))),
+                        (b"ATTACKS", chart.chart_attacks.unwrap_or(String::from(""))),
+                        (
+                            b"DISPLAYBPM",
+                            chart.chart_display_bpm.unwrap_or(String::from("")),
+                        ),
+                    ];
+
+                    for property in chart_timing_properties {
+                        written_bytes += serialize_prop(property.0, property.1.as_bytes(), out)?;
+                    }
+                }
+
+                // TODO: handle #NOTES2 correctly
+                written_bytes += out.write(b"#NOTES:\n")?;
+                written_bytes += out.write(&chart.minimized_note_data)?;
+                written_bytes += out.write(b";\n")?;
+            }
+        }
+        // SM
+        false => {
+            for chart in summary.charts {
+                written_bytes += out.write(b"#NOTES:\n")?;
+                written_bytes += serialize_sm_chart_field(&chart.step_type_str, out)?;
+                written_bytes += serialize_sm_chart_field(&chart.description_str, out)?;
+                written_bytes += serialize_sm_chart_field(&chart.difficulty_str, out)?;
+                written_bytes += serialize_sm_chart_field(&chart.rating_str, out)?;
+                // TODO: verify whether this actually mirrors the "description" field
+                written_bytes +=
+                    serialize_sm_chart_field(&format_radar_values(chart.cached_radar_values), out)?;
+                written_bytes += out.write(&chart.minimized_note_data)?;
+                written_bytes += out.write(b";\n")?;
+            }
+        }
+    }
+
+    Ok(written_bytes)
+}

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -2,19 +2,19 @@ use std::io;
 
 use rssp_core::parse::extension_is_ssc;
 
-pub(crate) const DEFAULT_VERSION: &[u8] = b"0.83";
-pub(crate) const DEFAULT_TITLE: &[u8] = b"Untitled";
-pub(crate) const DEFAULT_ARTIST: &[u8] = b"Unknown artist";
-pub(crate) const DEFAULT_BPMS: &[u8] = b"0.000000=60.000000";
-pub(crate) const DEFAULT_TIME_SIGNATURES: &[u8] = b"0.000000=4=4";
-pub(crate) const DEFAULT_TICKCOUNTS: &[u8] = b"0.000000=4";
-pub(crate) const DEFAULT_COMBOS: &[u8] = b"0.000000=1";
-pub(crate) const DEFAULT_SPEEDS: &[u8] = b"0.000000=1.000000=0.000000=0";
-pub(crate) const DEFAULT_SCROLLS: &[u8] = b"0.000000=1.000000";
-pub(crate) const DEFAULT_LABELS: &[u8] = b"0.000000=Song Start";
-pub(crate) const DEFAULT_STEPSTYPE: &[u8] = b"dance-single";
-pub(crate) const DEFAULT_DIFFICULTY: &[u8] = b"Beginner";
-pub(crate) const DEFAULT_METER: &[u8] = b"1";
+pub const DEFAULT_VERSION: &[u8] = b"0.83";
+pub const DEFAULT_TITLE: &[u8] = b"Untitled";
+pub const DEFAULT_ARTIST: &[u8] = b"Unknown artist";
+pub const DEFAULT_BPMS: &[u8] = b"0.000000=60.000000";
+pub const DEFAULT_TIME_SIGNATURES: &[u8] = b"0.000000=4=4";
+pub const DEFAULT_TICKCOUNTS: &[u8] = b"0.000000=4";
+pub const DEFAULT_COMBOS: &[u8] = b"0.000000=1";
+pub const DEFAULT_SPEEDS: &[u8] = b"0.000000=1.000000=0.000000=0";
+pub const DEFAULT_SCROLLS: &[u8] = b"0.000000=1.000000";
+pub const DEFAULT_LABELS: &[u8] = b"0.000000=Song Start";
+pub const DEFAULT_STEPSTYPE: &[u8] = b"dance-single";
+pub const DEFAULT_DIFFICULTY: &[u8] = b"Beginner";
+pub const DEFAULT_METER: &[u8] = b"1";
 
 /// Call `write_all` and, on success, return the input's size in bytes
 macro_rules! write_all {
@@ -57,8 +57,8 @@ fn format_dot6_f64(value: f64) -> String {
 
 #[must_use]
 #[inline(always)]
-fn format_dot3_f32(value: f32) -> String {
-    format!("{:.3}", value)
+fn format_dot6_f32(value: f32) -> String {
+    format!("{:.6}", value)
 }
 
 #[derive(Default)]
@@ -75,7 +75,7 @@ enum PropValue<'a> {
     Bool(bool),
     NormalizedList(&'a str),
     NormalizedListOpt(Option<&'a str>),
-    RadarValues(Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>),
+    RadarValues(Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>, bool),
 }
 
 impl<'a> PropValue<'a> {
@@ -122,17 +122,20 @@ impl<'a> PropValue<'a> {
                 None => Ok(0),
                 Some(items_str) => PropValue::NormalizedList(items_str).serialize(out),
             },
-            PropValue::RadarValues(rv) => match rv {
+            PropValue::RadarValues(rv, per_player) => match rv {
                 Some(values) => {
                     let mut written_bytes = 0;
                     let mut first_item = true;
+                    let players = if *per_player { 2 } else { 1 };
 
-                    for value in values {
-                        if !first_item {
-                            written_bytes += write_all!(out, b",")?;
+                    for _ in 0..players {
+                        for value in values {
+                            if !first_item {
+                                written_bytes += write_all!(out, b",")?;
+                            }
+                            written_bytes += write_all!(out, format_dot6_f32(*value).as_bytes())?;
+                            first_item = false;
                         }
-                        written_bytes += write_all!(out, format_dot3_f32(*value).as_bytes())?;
-                        first_item = false;
                     }
 
                     Ok(written_bytes)
@@ -156,7 +159,7 @@ impl<'a> PropValue<'a> {
             PropValue::Bool(_) => false,
             PropValue::NormalizedList(s) => s.is_empty(),
             PropValue::NormalizedListOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
-            PropValue::RadarValues(rv) => rv.is_none(),
+            PropValue::RadarValues(rv, _) => rv.is_none(),
         }
     }
 }
@@ -399,7 +402,7 @@ fn serialize_sm_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> i
         Prop::new(b"", PropValue::Str(&chart.description_str)),
         Prop::new_with_default(b"", DEFAULT_DIFFICULTY, PropValue::Str(&chart.difficulty_str)),
         Prop::new_with_default(b"", DEFAULT_METER, PropValue::Str(&chart.rating_str)),
-        Prop::new(b"", PropValue::RadarValues(chart.cached_radar_values)),
+        Prop::new(b"", PropValue::RadarValues(chart.cached_radar_values, false)),
     ];
 
     for prop in props {
@@ -431,7 +434,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::new_with_default(b"DIFFICULTY", DEFAULT_DIFFICULTY, PropValue::Str(&chart.difficulty_str)),
         Prop::new_with_default(b"METER", DEFAULT_METER, PropValue::Str(&chart.rating_str)),
         Prop::nonempty_only(b"MUSIC", PropValue::Str(&chart.music_path)),
-        Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values)),
+        Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values, true)),
         Prop::new(b"CREDIT", PropValue::Str(&chart.step_artist_str)),
         Prop::own_timing_only(b"OFFSET", PropValue::Number(chart.chart_offset_seconds)),
         Prop::own_timing_only_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedListOpt(chart.chart_bpms.as_deref())),

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -158,9 +158,9 @@ pub fn serialize_simfile(
         (b"ATTACKS", "", true, List),   // TODO
     ];
 
-    for property in properties {
-        if property.2 {
-            written_bytes += write_prop(property.0, property.1.as_bytes(), property.3, out)?;
+    for (key, value, is_included, value_writer) in properties {
+        if is_included {
+            written_bytes += write_prop(key, value.as_bytes(), value_writer, out)?;
         }
     }
 
@@ -336,9 +336,9 @@ fn serialize_ssc_chart_timing_fields(
         ),
     ];
 
-    for property in chart_timing_properties {
-        if property.3 {
-            written_bytes += write_prop(property.0, property.1.as_bytes(), property.2, out)?;
+    for (key, value, value_writer, is_included) in chart_timing_properties {
+        if is_included {
+            written_bytes += write_prop(key, value.as_bytes(), value_writer, out)?;
         }
     }
 

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -74,8 +74,6 @@ enum PropValue<'a> {
     Number(f64),
     NumberOpt(Option<f64>),
     Bool(bool),
-    NormalizedList(&'a str),
-    NormalizedListOpt(Option<&'a str>),
     RadarValues(Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>, bool),
 }
 
@@ -105,28 +103,6 @@ impl<'a> PropValue<'a> {
                     write_all!(out, b"NO")
                 }
             }
-            PropValue::NormalizedList(items_str) => {
-                let items = items_str.as_bytes();
-                let mut written_bytes = 0;
-                let mut start = 0;
-
-                while let Some(offset) = items[start..].iter().position(|&b| b == b',') {
-                    let comma = start + offset;
-                    written_bytes += write_all!(out, &items[start..=comma])?;
-                    written_bytes += write_all!(out, b"\n")?;
-                    start = comma + 1;
-                    while start < items.len() && items[start].is_ascii_whitespace() {
-                        start += 1;
-                    }
-                }
-
-                written_bytes += write_all!(out, &items[start..])?;
-                Ok(written_bytes)
-            }
-            PropValue::NormalizedListOpt(opt_items_str) => match opt_items_str {
-                None => Ok(0),
-                Some(items_str) => PropValue::NormalizedList(items_str).serialize(out),
-            },
             PropValue::RadarValues(rv, per_player) => match rv {
                 Some(values) => {
                     let mut written_bytes = 0;
@@ -163,8 +139,6 @@ impl<'a> PropValue<'a> {
             PropValue::Number(_) => false,
             PropValue::NumberOpt(opt) => opt.is_none(),
             PropValue::Bool(_) => false,
-            PropValue::NormalizedList(s) => s.is_empty(),
-            PropValue::NormalizedListOpt(opt) => opt.as_ref().is_none_or(|s| s.is_empty()),
             PropValue::RadarValues(rv, _) => rv.is_none(),
         }
     }
@@ -327,21 +301,21 @@ pub fn serialize_simfile(
         Prop::new(b"SAMPLELENGTH", PropValue::Number(summary.sample_length)),
         Prop::new(b"SELECTABLE", PropValue::Bool(summary.selectable)),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscape(&summary.display_bpm_str)),
-        Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedList(&summary.normalized_bpms)),
-        Prop::new(b"STOPS", PropValue::NormalizedList(&summary.normalized_stops)),
-        Prop::ssc_only(b"DELAYS", PropValue::NormalizedList(&summary.normalized_delays)),
-        Prop::ssc_only(b"WARPS", PropValue::NormalizedList(&summary.normalized_warps)),
-        Prop::ssc_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::NormalizedList(&summary.normalized_time_signatures)),
-        Prop::ssc_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::NormalizedList(&summary.normalized_tickcounts)),
-        Prop::ssc_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::NormalizedList(&summary.normalized_combos)),
-        Prop::ssc_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::NormalizedList(&summary.normalized_speeds)),
-        Prop::ssc_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedList(&summary.normalized_scrolls)),
-        Prop::ssc_only(b"FAKES", PropValue::NormalizedList(&summary.normalized_fakes)),
-        Prop::ssc_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedList(&summary.normalized_labels)),
+        Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::StrNoEscape(&summary.normalized_bpms)),
+        Prop::new(b"STOPS", PropValue::StrNoEscape(&summary.normalized_stops)),
+        Prop::ssc_only(b"DELAYS", PropValue::StrNoEscape(&summary.normalized_delays)),
+        Prop::ssc_only(b"WARPS", PropValue::StrNoEscape(&summary.normalized_warps)),
+        Prop::ssc_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::StrNoEscape(&summary.normalized_time_signatures)),
+        Prop::ssc_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::StrNoEscape(&summary.normalized_tickcounts)),
+        Prop::ssc_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::StrNoEscape(&summary.normalized_combos)),
+        Prop::ssc_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::StrNoEscape(&summary.normalized_speeds)),
+        Prop::ssc_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::StrNoEscape(&summary.normalized_scrolls)),
+        Prop::ssc_only(b"FAKES", PropValue::StrNoEscape(&summary.normalized_fakes)),
+        Prop::ssc_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::StrNoEscape(&summary.normalized_labels)),
         Prop::ssc_nonempty_only(b"LASTSECONDHINT", PropValue::NumberOpt(summary.last_second_hint)),
         Prop::new(b"BGCHANGES", PropValue::StrNoEscape(&summary.normalized_bgchanges)),
         Prop::nonempty_only(b"FGCHANGES", PropValue::StrNoEscape(&summary.normalized_fgchanges)),
-        Prop::new(b"KEYSOUNDS", PropValue::NormalizedList(&summary.normalized_keysounds)),
+        Prop::new(b"KEYSOUNDS", PropValue::StrNoEscape(&summary.normalized_keysounds)),
         Prop::new(b"ATTACKS", PropValue::StrNoEscape(&summary.normalized_attacks)), // Commas aren't always row separators
     ];
 
@@ -352,6 +326,7 @@ pub fn serialize_simfile(
     written_bytes += write_all!(out, b"\n")?;
 
     for chart in &summary.charts {
+        written_bytes += write_chart_comment_prefix(out, chart)?;
         written_bytes += if ssc {
             serialize_ssc_chart(out, chart)
         } else {
@@ -359,6 +334,35 @@ pub fn serialize_simfile(
         }?;
         written_bytes += write_all!(out, b"\n")?;
     }
+
+    Ok(written_bytes)
+}
+
+#[must_use]
+fn write_chart_comment_prefix(
+    out: &mut dyn io::Write,
+    chart: &crate::ChartSummary,
+) -> io::Result<usize> {
+    let mut written_bytes: usize = 0;
+
+    written_bytes += write_all!(out, b"//---------------")?;
+    match chart.step_type_str.as_ref() {
+        "" => {
+            written_bytes += write_all!(out, DEFAULT_STEPSTYPE)?;
+        }
+        s => {
+            // Passively strip newlines to ensure that we never terminate the comment prematurely
+            for line in s.lines() {
+                written_bytes += write_all!(out, line.as_bytes())?;
+            }
+        }
+    };
+    written_bytes += write_all!(out, b" - ")?;
+    // Passively strip newlines again
+    for line in chart.description_str.lines() {
+        written_bytes += write_all!(out, line.as_bytes())?;
+    }
+    written_bytes += write_all!(out, b"----------------\n")?;
 
     Ok(written_bytes)
 }
@@ -411,17 +415,17 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values, true)),
         Prop::new(b"CREDIT", PropValue::Str(&chart.step_artist_str)),
         Prop::own_timing_only(b"OFFSET", PropValue::Number(chart.chart_offset_seconds)),
-        Prop::own_timing_only_with_default(b"BPMS", DEFAULT_BPMS, PropValue::NormalizedListOpt(chart.chart_bpms.as_deref())),
-        Prop::own_timing_only(b"STOPS", PropValue::NormalizedListOpt(chart.chart_stops.as_deref())),
-        Prop::own_timing_only(b"DELAYS", PropValue::NormalizedListOpt(chart.chart_delays.as_deref())),
-        Prop::own_timing_only(b"WARPS", PropValue::NormalizedListOpt(chart.chart_warps.as_deref())),
-        Prop::own_timing_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::NormalizedListOpt(chart.chart_time_signatures.as_deref())),
-        Prop::own_timing_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::NormalizedListOpt(chart.chart_tickcounts.as_deref())),
-        Prop::own_timing_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::NormalizedListOpt(chart.chart_combos.as_deref())),
-        Prop::own_timing_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::NormalizedListOpt(chart.chart_speeds.as_deref())),
-        Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::NormalizedListOpt(chart.chart_scrolls.as_deref())),
-        Prop::own_timing_only(b"FAKES", PropValue::NormalizedListOpt(chart.chart_fakes.as_deref())),
-        Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::NormalizedListOpt(chart.chart_labels.as_deref())),
+        Prop::own_timing_only_with_default(b"BPMS", DEFAULT_BPMS, PropValue::StrNoEscapeOpt(chart.chart_bpms.as_deref())),
+        Prop::own_timing_only(b"STOPS", PropValue::StrNoEscapeOpt(chart.chart_stops.as_deref())),
+        Prop::own_timing_only(b"DELAYS", PropValue::StrNoEscapeOpt(chart.chart_delays.as_deref())),
+        Prop::own_timing_only(b"WARPS", PropValue::StrNoEscapeOpt(chart.chart_warps.as_deref())),
+        Prop::own_timing_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::StrNoEscapeOpt(chart.chart_time_signatures.as_deref())),
+        Prop::own_timing_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::StrNoEscapeOpt(chart.chart_tickcounts.as_deref())),
+        Prop::own_timing_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::StrNoEscapeOpt(chart.chart_combos.as_deref())),
+        Prop::own_timing_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::StrNoEscapeOpt(chart.chart_speeds.as_deref())),
+        Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::StrNoEscapeOpt(chart.chart_scrolls.as_deref())),
+        Prop::own_timing_only(b"FAKES", PropValue::StrNoEscapeOpt(chart.chart_fakes.as_deref())),
+        Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::StrNoEscapeOpt(chart.chart_labels.as_deref())),
         Prop::nonempty_only(b"ATTACKS", PropValue::StrNoEscapeOpt(chart.chart_attacks.as_deref())),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscapeOpt(chart.chart_display_bpm.as_deref())),
         Prop::nonempty_only(b"NOTES", PropValue::NoteData(&chart.minimized_note_data)),
@@ -513,6 +517,7 @@ mod tests {
             #KEYSOUNDS:;\n\
             #ATTACKS:;\n\
             \n\
+            //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
@@ -530,6 +535,7 @@ mod tests {
             0000\n\
             ;\n\
             \n\
+            //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
@@ -657,6 +663,7 @@ mod tests {
             #KEYSOUNDS:;\n\
             #ATTACKS:Attacks;\n\
             \n\
+            //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
@@ -677,6 +684,7 @@ mod tests {
             0000\n\
             ;\n\
             \n\
+            //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
@@ -791,6 +799,7 @@ mod tests {
             #KEYSOUNDS:;\n\
             #ATTACKS:;\n\
             \n\
+            //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
@@ -808,6 +817,7 @@ mod tests {
             0000\n\
             ;\n\
             \n\
+            //---------------dance-single - Description----------------\n\
             #NOTEDATA:;\n\
             #CHARTNAME:Chart name;\n\
             #STEPSTYPE:dance-single;\n\
@@ -888,6 +898,7 @@ mod tests {
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
         \n\
+        //---------------dance-single - Description----------------\n\
         #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
         0000\n\
         0000\n\
@@ -944,6 +955,7 @@ mod tests {
         #KEYSOUNDS:;\n\
         #ATTACKS:Attacks;\n\
         \n\
+        //---------------dance-single - Description----------------\n\
         #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
         0000\n\
         0000\n\
@@ -996,6 +1008,7 @@ mod tests {
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
         \n\
+        //---------------dance-single - Description----------------\n\
         #NOTES:\n     dance-single:\n     Description:\n     Beginner:\n     1:\n     0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000:\n\
         0000\n\
         0000\n\
@@ -1049,37 +1062,37 @@ mod tests {
             artisttranslit_str: String::from("Artist translit"),
             offset: 0.123,
             normalized_bpms: match trigger_defaults {
-                false => String::from("0.000=120.000,16.000=240.000,48.000=120.000"),
+                false => String::from("0.000=120.000,\n16.000=240.000,\n48.000=120.000"),
                 true => String::from(""),
             },
-            normalized_stops: String::from("1.000=1.250,1.500=1.750"),
-            normalized_delays: String::from("2.000=2.250,2.500=2.750"),
-            normalized_warps: String::from("3.000=3.250,3.500=3.750"),
+            normalized_stops: String::from("1.000=1.250,\n1.500=1.750"),
+            normalized_delays: String::from("2.000=2.250,\n2.500=2.750"),
+            normalized_warps: String::from("3.000=3.250,\n3.500=3.750"),
             normalized_speeds: match trigger_defaults {
-                false => {
-                    String::from("0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1")
-                }
+                false => String::from(
+                    "0.000=1.000=0.000=0,\n12.000=0.500=4.000=0,\n48.000=1.000=0.000=1",
+                ),
                 true => String::from(""),
             },
             normalized_scrolls: match trigger_defaults {
-                false => String::from("0.000=1.000,16.000=2.000,48.000=1.000"),
+                false => String::from("0.000=1.000,\n16.000=2.000,\n48.000=1.000"),
                 true => String::from(""),
             },
-            normalized_fakes: String::from("4.000=4.250,4.500=4.750"),
+            normalized_fakes: String::from("4.000=4.250,\n4.500=4.750"),
             normalized_time_signatures: match trigger_defaults {
-                false => String::from("0.000=4=4,16.000=8=4,48.000=4=4"),
+                false => String::from("0.000=4=4,\n16.000=8=4,\n48.000=4=4"),
                 true => String::from(""),
             },
             normalized_labels: match trigger_defaults {
-                false => String::from("0.000=Song Start,16.000=Speedup"),
+                false => String::from("0.000=Song Start,\n16.000=Speedup"),
                 true => String::from(""),
             },
             normalized_tickcounts: match trigger_defaults {
-                false => String::from("0.000=4,16.000=2,48.000=4"),
+                false => String::from("0.000=4,\n16.000=2,\n48.000=4"),
                 true => String::from(""),
             },
             normalized_combos: match trigger_defaults {
-                false => String::from("0.000=1,16.000=2,48.000=1"),
+                false => String::from("0.000=1,\n16.000=2,\n48.000=1"),
                 true => String::from(""),
             },
             ssc_version: 0.83,
@@ -1168,24 +1181,24 @@ mod tests {
             // Timing fields
             chart_has_own_timing: has_own_timing,
             chart_bpms: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=120.000,16.000=240.000,48.000=120.000")),
-            chart_stops: has_own_timing.then(|| String::from("1.000=1.250,1.500=1.750")),
-            chart_delays: has_own_timing.then(|| String::from("2.000=2.250,2.500=2.750")),
-            chart_warps: has_own_timing.then(|| String::from("3.000=3.250,3.500=3.750")),
+                .then(|| String::from("0.000=120.000,\n16.000=240.000,\n48.000=120.000")),
+            chart_stops: has_own_timing.then(|| String::from("1.000=1.250,\n1.500=1.750")),
+            chart_delays: has_own_timing.then(|| String::from("2.000=2.250,\n2.500=2.750")),
+            chart_warps: has_own_timing.then(|| String::from("3.000=3.250,\n3.500=3.750")),
             chart_speeds: (has_own_timing && !trigger_defaults).then(|| {
-                String::from("0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1")
+                String::from("0.000=1.000=0.000=0,\n12.000=0.500=4.000=0,\n48.000=1.000=0.000=1")
             }),
             chart_scrolls: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=1.000,16.000=2.000,48.000=1.000")),
-            chart_fakes: has_own_timing.then(|| String::from("4.000=4.250,4.500=4.750")),
+                .then(|| String::from("0.000=1.000,\n16.000=2.000,\n48.000=1.000")),
+            chart_fakes: has_own_timing.then(|| String::from("4.000=4.250,\n4.500=4.750")),
             chart_time_signatures: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=4=4,16.000=8=4,48.000=4=4")),
+                .then(|| String::from("0.000=4=4,\n16.000=8=4,\n48.000=4=4")),
             chart_labels: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=Song Start,16.000=Speedup")),
+                .then(|| String::from("0.000=Song Start,\n16.000=Speedup")),
             chart_tickcounts: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=4,16.000=2,48.000=4")),
+                .then(|| String::from("0.000=4,\n16.000=2,\n48.000=4")),
             chart_combos: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=1,16.000=2,48.000=1")),
+                .then(|| String::from("0.000=1,\n16.000=2,\n48.000=1")),
             chart_attacks: include_nonempty.then(|| String::from("Attacks")), // TODO
             chart_display_bpm: include_nonempty.then(|| String::from("300")),
 

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -12,6 +12,9 @@ pub(crate) const DEFAULT_COMBOS: &[u8] = b"0.000000=1";
 pub(crate) const DEFAULT_SPEEDS: &[u8] = b"0.000000=1.000000=0.000000=0";
 pub(crate) const DEFAULT_SCROLLS: &[u8] = b"0.000000=1.000000";
 pub(crate) const DEFAULT_LABELS: &[u8] = b"0.000000=Song Start";
+pub(crate) const DEFAULT_STEPSTYPE: &[u8] = b"dance-single";
+pub(crate) const DEFAULT_DIFFICULTY: &[u8] = b"Beginner";
+pub(crate) const DEFAULT_METER: &[u8] = b"1";
 
 /// Call `write_all` and, on success, return the input's size in bytes
 macro_rules! write_all {
@@ -459,6 +462,17 @@ pub fn serialize_simfile(
     out: &mut dyn io::Write,
 ) -> io::Result<usize> {
     let ssc = extension_is_ssc(extension)?;
+    if !ssc {
+        for chart in &summary.charts {
+            if chart.chart_has_own_timing {
+                return io::Result::Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Can't serialize chart with its own timing to .sm",
+                ));
+            }
+        }
+    }
+
     let mut written_bytes = 0;
 
     #[rustfmt::skip]
@@ -537,11 +551,28 @@ fn write_sm_chart_field(value: &str, out: &mut dyn io::Write) -> io::Result<usiz
 fn serialize_sm_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> io::Result<usize> {
     let mut written_bytes = 0;
     written_bytes += write_all!(out, b"#NOTES:\n")?;
-    written_bytes += write_sm_chart_field(&chart.step_type_str, out)?;
-    written_bytes += write_sm_chart_field(&chart.description_str, out)?;
-    written_bytes += write_sm_chart_field(&chart.difficulty_str, out)?;
-    written_bytes += write_sm_chart_field(&chart.rating_str, out)?;
-    written_bytes += write_sm_chart_field(&format_radar_values(chart.cached_radar_values), out)?;
+
+    // Kludge: don't use `Prop#serialize` here because SM charts are special.
+    // We use `Prop` anyway for the sake of `new_with_default`.
+    #[rustfmt::skip]
+    let props = [
+        Prop::new_with_default(b"", DEFAULT_STEPSTYPE, PropValue::Str(&chart.step_type_str)),
+        Prop::new(b"", PropValue::Str(&chart.description_str)),
+        Prop::new_with_default(b"", DEFAULT_DIFFICULTY, PropValue::Str(&chart.difficulty_str)),
+        Prop::new_with_default(b"", DEFAULT_METER, PropValue::Str(&chart.rating_str)),
+        Prop::new(b"", PropValue::RadarValues(chart.cached_radar_values)),
+    ];
+
+    for prop in props {
+        let value = match (prop.default_value, prop.value.is_empty()) {
+            (Some(default), true) => PropValue::Bytes(default),
+            _ => prop.value,
+        };
+        written_bytes += write_all!(out, b"     ")?;
+        written_bytes += value.serialize(out)?;
+        written_bytes += write_all!(out, b":\n")?;
+    }
+
     written_bytes += write_all!(out, &chart.minimized_note_data)?;
     written_bytes += write_all!(out, b";\n")?;
     Ok(written_bytes)
@@ -555,11 +586,11 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
     let props = [
         Prop::new(b"NOTEDATA", PropValue::Empty),
         Prop::new(b"CHARTNAME", PropValue::Str(&chart.chart_name_str)),
-        Prop::new_with_default(b"STEPSTYPE", b"dance-single", PropValue::Str(&chart.step_type_str)),
+        Prop::new_with_default(b"STEPSTYPE", DEFAULT_STEPSTYPE, PropValue::Str(&chart.step_type_str)),
         Prop::new(b"DESCRIPTION", PropValue::Str(&chart.description_str)),
         Prop::new(b"CHARTSTYLE", PropValue::Str(&chart.chart_style_str)),
-        Prop::new_with_default(b"DIFFICULTY", b"Beginner", PropValue::Str(&chart.difficulty_str)),
-        Prop::new_with_default(b"METER", b"1", PropValue::Str(&chart.rating_str)),
+        Prop::new_with_default(b"DIFFICULTY", DEFAULT_DIFFICULTY, PropValue::Str(&chart.difficulty_str)),
+        Prop::new_with_default(b"METER", DEFAULT_METER, PropValue::Str(&chart.rating_str)),
         Prop::nonempty_only(b"MUSIC", PropValue::Str(&chart.music_path)), // TODO
         Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values)),
         Prop::new(b"CREDIT", PropValue::Str(&chart.step_artist_str)),
@@ -596,9 +627,13 @@ mod tests {
 
     #[test]
     fn serialize_simfile_with_ssc() -> io::Result<()> {
-        let mut summary = simfile_summary_with_all_fields();
-        summary.charts.push(chart_summary_with_all_fields(false));
-        summary.charts.push(chart_summary_with_all_fields(true));
+        let mut summary = simfile_summary_with_all_fields(false, false);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(false, false, false));
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(true, false, false));
         let mut buffer = vec![];
         {
             let mut cursor = io::Cursor::new(&mut buffer);
@@ -630,7 +665,6 @@ mod tests {
             #SAMPLESTART:10.000000;\n\
             #SAMPLELENGTH:16.000000;\n\
             #SELECTABLE:YES;\n\
-            #DISPLAYBPM:150;\n\
             #BPMS:0.000=120.000,\n\
             16.000=240.000,\n\
             48.000=120.000;\n\
@@ -717,7 +751,267 @@ mod tests {
             4.500=4.750;\n\
             #LABELS:0.000=Song Start,\n\
             16.000=Speedup;\n\
+            #NOTES:\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            ;\n\
+            \n";
+
+        assert_eq!(expected, output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_simfile_with_ssc_and_nonempty_fields() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields(true, false);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(false, true, false));
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(true, true, false));
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+            super::serialize_simfile(&summary, "ssc", &mut cursor)?;
+        };
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        let expected = "#VERSION:0.83;\n\
+            #TITLE:Title;\n\
+            #SUBTITLE:Subtitle;\n\
+            #ARTIST:Artist;\n\
+            #TITLETRANSLIT:Title translit;\n\
+            #SUBTITLETRANSLIT:Subtitle translit;\n\
+            #ARTISTTRANSLIT:Artist translit;\n\
+            #GENRE:Genre;\n\
+            #ORIGIN:Origin;\n\
+            #CREDIT:Credit;\n\
+            #BANNER:banner.png;\n\
+            #BACKGROUND:background.png;\n\
+            #PREVIEWVID:previewvid.mov;\n\
+            #JACKET:jacket.png;\n\
+            #CDIMAGE:cdimage.png;\n\
+            #DISCIMAGE:discimage.png;\n\
+            #LYRICSPATH:lyrics.lrc;\n\
+            #CDTITLE:cdtitle.png;\n\
+            #MUSIC:music.ogg;\n\
+            #OFFSET:0.123000;\n\
+            #SAMPLESTART:10.000000;\n\
+            #SAMPLELENGTH:16.000000;\n\
+            #SELECTABLE:YES;\n\
             #DISPLAYBPM:150;\n\
+            #BPMS:0.000=120.000,\n\
+            16.000=240.000,\n\
+            48.000=120.000;\n\
+            #STOPS:1.000=1.250,\n\
+            1.500=1.750;\n\
+            #DELAYS:2.000=2.250,\n\
+            2.500=2.750;\n\
+            #WARPS:3.000=3.250,\n\
+            3.500=3.750;\n\
+            #TIMESIGNATURES:0.000=4=4,\n\
+            16.000=8=4,\n\
+            48.000=4=4;\n\
+            #TICKCOUNTS:0.000=4,\n\
+            16.000=2,\n\
+            48.000=4;\n\
+            #COMBOS:0.000=1,\n\
+            16.000=2,\n\
+            48.000=1;\n\
+            #SPEEDS:0.000=1.000=0.000=0,\n\
+            12.000=0.500=4.000=0,\n\
+            48.000=1.000=0.000=1;\n\
+            #SCROLLS:0.000=1.000,\n\
+            16.000=2.000,\n\
+            48.000=1.000;\n\
+            #FAKES:4.000=4.250,\n\
+            4.500=4.750;\n\
+            #LABELS:0.000=Song Start,\n\
+            16.000=Speedup;\n\
+            #LASTSECONDHINT:120.000000;\n\
+            #BGCHANGES:;\n\
+            #FGCHANGES:;\n\
+            #KEYSOUNDS:;\n\
+            #ATTACKS:;\n\
+            \n\
+            #NOTEDATA:;\n\
+            #CHARTNAME:Chart name;\n\
+            #STEPSTYPE:dance-single;\n\
+            #DESCRIPTION:Description;\n\
+            #CHARTSTYLE:Chart style;\n\
+            #DIFFICULTY:Challenge;\n\
+            #METER:17;\n\
+            #MUSIC:chart_music.ogg;\n\
+            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #CREDIT:Step artist;\n\
+            #ATTACKS:;\n\
+            #DISPLAYBPM:300;\n\
+            #NOTES:\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            ;\n\
+            \n\
+            #NOTEDATA:;\n\
+            #CHARTNAME:Chart name;\n\
+            #STEPSTYPE:dance-single;\n\
+            #DESCRIPTION:Description;\n\
+            #CHARTSTYLE:Chart style;\n\
+            #DIFFICULTY:Challenge;\n\
+            #METER:17;\n\
+            #MUSIC:chart_music.ogg;\n\
+            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #CREDIT:Step artist;\n\
+            #OFFSET:0.000000;\n\
+            #BPMS:0.000=120.000,\n\
+            16.000=240.000,\n\
+            48.000=120.000;\n\
+            #STOPS:1.000=1.250,\n\
+            1.500=1.750;\n\
+            #DELAYS:2.000=2.250,\n\
+            2.500=2.750;\n\
+            #WARPS:3.000=3.250,\n\
+            3.500=3.750;\n\
+            #TIMESIGNATURES:0.000=4=4,\n\
+            16.000=8=4,\n\
+            48.000=4=4;\n\
+            #TICKCOUNTS:0.000=4,\n\
+            16.000=2,\n\
+            48.000=4;\n\
+            #COMBOS:0.000=1,\n\
+            16.000=2,\n\
+            48.000=1;\n\
+            #SPEEDS:0.000=1.000=0.000=0,\n\
+            12.000=0.500=4.000=0,\n\
+            48.000=1.000=0.000=1;\n\
+            #SCROLLS:0.000=1.000,\n\
+            16.000=2.000,\n\
+            48.000=1.000;\n\
+            #FAKES:4.000=4.250,\n\
+            4.500=4.750;\n\
+            #LABELS:0.000=Song Start,\n\
+            16.000=Speedup;\n\
+            #ATTACKS:;\n\
+            #DISPLAYBPM:300;\n\
+            #NOTES:\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            ;\n\
+            \n";
+
+        assert_eq!(expected, output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_simfile_with_ssc_and_trigger_defaults() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields(false, true);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(false, false, true));
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(true, false, true));
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+            super::serialize_simfile(&summary, "ssc", &mut cursor)?;
+        };
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        let expected = "#VERSION:0.83;\n\
+            #TITLE:Untitled;\n\
+            #SUBTITLE:Subtitle;\n\
+            #ARTIST:Unknown artist;\n\
+            #TITLETRANSLIT:Title translit;\n\
+            #SUBTITLETRANSLIT:Subtitle translit;\n\
+            #ARTISTTRANSLIT:Artist translit;\n\
+            #GENRE:Genre;\n\
+            #ORIGIN:Origin;\n\
+            #CREDIT:Credit;\n\
+            #BANNER:banner.png;\n\
+            #BACKGROUND:background.png;\n\
+            #PREVIEWVID:previewvid.mov;\n\
+            #JACKET:jacket.png;\n\
+            #CDIMAGE:cdimage.png;\n\
+            #DISCIMAGE:discimage.png;\n\
+            #LYRICSPATH:lyrics.lrc;\n\
+            #CDTITLE:cdtitle.png;\n\
+            #MUSIC:music.ogg;\n\
+            #OFFSET:0.123000;\n\
+            #SAMPLESTART:10.000000;\n\
+            #SAMPLELENGTH:16.000000;\n\
+            #SELECTABLE:YES;\n\
+            #BPMS:0.000000=60.000000;\n\
+            #STOPS:1.000=1.250,\n\
+            1.500=1.750;\n\
+            #DELAYS:2.000=2.250,\n\
+            2.500=2.750;\n\
+            #WARPS:3.000=3.250,\n\
+            3.500=3.750;\n\
+            #TIMESIGNATURES:0.000000=4=4;\n\
+            #TICKCOUNTS:0.000000=4;\n\
+            #COMBOS:0.000000=1;\n\
+            #SPEEDS:0.000000=1.000000=0.000000=0;\n\
+            #SCROLLS:0.000000=1.000000;\n\
+            #FAKES:4.000=4.250,\n\
+            4.500=4.750;\n\
+            #LABELS:0.000000=Song Start;\n\
+            #BGCHANGES:;\n\
+            #KEYSOUNDS:;\n\
+            #ATTACKS:;\n\
+            \n\
+            #NOTEDATA:;\n\
+            #CHARTNAME:Chart name;\n\
+            #STEPSTYPE:dance-single;\n\
+            #DESCRIPTION:Description;\n\
+            #CHARTSTYLE:Chart style;\n\
+            #DIFFICULTY:Beginner;\n\
+            #METER:1;\n\
+            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #CREDIT:Step artist;\n\
+            #NOTES:\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            0000\n\
+            ;\n\
+            \n\
+            #NOTEDATA:;\n\
+            #CHARTNAME:Chart name;\n\
+            #STEPSTYPE:dance-single;\n\
+            #DESCRIPTION:Description;\n\
+            #CHARTSTYLE:Chart style;\n\
+            #DIFFICULTY:Beginner;\n\
+            #METER:1;\n\
+            #RADARVALUES:0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140;\n\
+            #CREDIT:Step artist;\n\
+            #OFFSET:0.000000;\n\
+            #BPMS:0.000000=60.000000;\n\
+            #STOPS:1.000=1.250,\n\
+            1.500=1.750;\n\
+            #DELAYS:2.000=2.250,\n\
+            2.500=2.750;\n\
+            #WARPS:3.000=3.250,\n\
+            3.500=3.750;\n\
+            #TIMESIGNATURES:0.000000=4=4;\n\
+            #TICKCOUNTS:0.000000=4;\n\
+            #COMBOS:0.000000=1;\n\
+            #SPEEDS:0.000000=1.000000=0.000000=0;\n\
+            #SCROLLS:0.000000=1.000000;\n\
+            #FAKES:4.000=4.250,\n\
+            4.500=4.750;\n\
+            #LABELS:0.000000=Song Start;\n\
             #NOTES:\n\
             0000\n\
             0000\n\
@@ -733,9 +1027,65 @@ mod tests {
 
     #[test]
     fn serialize_simfile_with_sm() -> io::Result<()> {
-        let mut summary = simfile_summary_with_all_fields();
-        summary.charts.push(chart_summary_with_all_fields(false));
-        summary.charts.push(chart_summary_with_all_fields(true));
+        let mut summary = simfile_summary_with_all_fields(false, false);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(false, false, false));
+
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+            super::serialize_simfile(&summary, "sm", &mut cursor)?;
+        };
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        let expected = "#TITLE:Title;\n\
+        #SUBTITLE:Subtitle;\n\
+        #ARTIST:Artist;\n\
+        #TITLETRANSLIT:Title translit;\n\
+        #SUBTITLETRANSLIT:Subtitle translit;\n\
+        #ARTISTTRANSLIT:Artist translit;\n\
+        #GENRE:Genre;\n\
+        #CREDIT:Credit;\n\
+        #BANNER:banner.png;\n\
+        #BACKGROUND:background.png;\n\
+        #LYRICSPATH:lyrics.lrc;\n\
+        #CDTITLE:cdtitle.png;\n\
+        #MUSIC:music.ogg;\n\
+        #OFFSET:0.123000;\n\
+        #SAMPLESTART:10.000000;\n\
+        #SAMPLELENGTH:16.000000;\n\
+        #SELECTABLE:YES;\n\
+        #BPMS:0.000=120.000,\n\
+        16.000=240.000,\n\
+        48.000=120.000;\n\
+        #STOPS:1.000=1.250,\n\
+        1.500=1.750;\n\
+        #BGCHANGES:;\n\
+        #KEYSOUNDS:;\n\
+        #ATTACKS:;\n\
+        \n\
+        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        ;\n\
+        \n";
+
+        assert_eq!(expected, output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_simfile_with_sm_and_nonempty_fields() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields(true, false);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(false, true, false));
+
         let mut buffer = vec![];
         {
             let mut cursor = io::Cursor::new(&mut buffer);
@@ -768,15 +1118,9 @@ mod tests {
         #STOPS:1.000=1.250,\n\
         1.500=1.750;\n\
         #BGCHANGES:;\n\
+        #FGCHANGES:;\n\
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
-        \n\
-        #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
-        0000\n\
-        0000\n\
-        0000\n\
-        0000\n\
-        ;\n\
         \n\
         #NOTES:\n     dance-single:\n     Description:\n     Challenge:\n     17:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
         0000\n\
@@ -791,29 +1135,131 @@ mod tests {
         Ok(())
     }
 
-    fn simfile_summary_with_all_fields(include_nonempty: bool) -> crate::SimfileSummary {
+    #[test]
+    fn serialize_simfile_with_sm_and_trigger_defaults() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields(false, true);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(false, false, true));
+
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+            super::serialize_simfile(&summary, "sm", &mut cursor)?;
+        };
+
+        let output = String::from_utf8(buffer).unwrap();
+
+        let expected = "#TITLE:Untitled;\n\
+        #SUBTITLE:Subtitle;\n\
+        #ARTIST:Unknown artist;\n\
+        #TITLETRANSLIT:Title translit;\n\
+        #SUBTITLETRANSLIT:Subtitle translit;\n\
+        #ARTISTTRANSLIT:Artist translit;\n\
+        #GENRE:Genre;\n\
+        #CREDIT:Credit;\n\
+        #BANNER:banner.png;\n\
+        #BACKGROUND:background.png;\n\
+        #LYRICSPATH:lyrics.lrc;\n\
+        #CDTITLE:cdtitle.png;\n\
+        #MUSIC:music.ogg;\n\
+        #OFFSET:0.123000;\n\
+        #SAMPLESTART:10.000000;\n\
+        #SAMPLELENGTH:16.000000;\n\
+        #SELECTABLE:YES;\n\
+        #BPMS:0.000000=60.000000;\n\
+        #STOPS:1.000=1.250,\n\
+        1.500=1.750;\n\
+        #BGCHANGES:;\n\
+        #KEYSOUNDS:;\n\
+        #ATTACKS:;\n\
+        \n\
+        #NOTES:\n     dance-single:\n     Description:\n     Beginner:\n     1:\n     0.010,0.020,0.030,0.040,0.050,0.060,0.070,0.080,0.090,0.100,0.110,0.120,0.130,0.140:\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        0000\n\
+        ;\n\
+        \n";
+
+        assert_eq!(expected, output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_simfile_with_sm_and_chart_timing_returns_error() -> io::Result<()> {
+        let mut summary = simfile_summary_with_all_fields(true, false);
+        summary
+            .charts
+            .push(chart_summary_with_all_fields(true, false, false));
+
+        let mut buffer = vec![];
+        {
+            let mut cursor = io::Cursor::new(&mut buffer);
+
+            match super::serialize_simfile(&summary, "sm", &mut cursor) {
+                Ok(_) => panic!("serialize_simfile returned Ok but a chart has its own timing"),
+                Err(_) => {}
+            }
+        };
+
+        Ok(())
+    }
+
+    fn simfile_summary_with_all_fields(
+        include_nonempty: bool,
+        trigger_defaults: bool,
+    ) -> crate::SimfileSummary {
         crate::SimfileSummary {
-            title_str: String::from("Title"),
+            title_str: match trigger_defaults {
+                false => String::from("Title"),
+                true => String::from(""),
+            },
             subtitle_str: String::from("Subtitle"),
-            artist_str: String::from("Artist"),
+            artist_str: match trigger_defaults {
+                false => String::from("Artist"),
+                true => String::from(""),
+            },
             genre_str: String::from("Genre"),
             titletranslit_str: String::from("Title translit"),
             subtitletranslit_str: String::from("Subtitle translit"),
             artisttranslit_str: String::from("Artist translit"),
             offset: 0.123,
-            normalized_bpms: String::from("0.000=120.000,16.000=240.000,48.000=120.000"),
+            normalized_bpms: match trigger_defaults {
+                false => String::from("0.000=120.000,16.000=240.000,48.000=120.000"),
+                true => String::from(""),
+            },
             normalized_stops: String::from("1.000=1.250,1.500=1.750"),
             normalized_delays: String::from("2.000=2.250,2.500=2.750"),
             normalized_warps: String::from("3.000=3.250,3.500=3.750"),
-            normalized_speeds: String::from(
-                "0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1",
-            ),
-            normalized_scrolls: String::from("0.000=1.000,16.000=2.000,48.000=1.000"),
+            normalized_speeds: match trigger_defaults {
+                false => {
+                    String::from("0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1")
+                }
+                true => String::from(""),
+            },
+            normalized_scrolls: match trigger_defaults {
+                false => String::from("0.000=1.000,16.000=2.000,48.000=1.000"),
+                true => String::from(""),
+            },
             normalized_fakes: String::from("4.000=4.250,4.500=4.750"),
-            normalized_time_signatures: String::from("0.000=4=4,16.000=8=4,48.000=4=4"),
-            normalized_labels: String::from("0.000=Song Start,16.000=Speedup"),
-            normalized_tickcounts: String::from("0.000=4,16.000=2,48.000=4"),
-            normalized_combos: String::from("0.000=1,16.000=2,48.000=1"),
+            normalized_time_signatures: match trigger_defaults {
+                false => String::from("0.000=4=4,16.000=8=4,48.000=4=4"),
+                true => String::from(""),
+            },
+            normalized_labels: match trigger_defaults {
+                false => String::from("0.000=Song Start,16.000=Speedup"),
+                true => String::from(""),
+            },
+            normalized_tickcounts: match trigger_defaults {
+                false => String::from("0.000=4,16.000=2,48.000=4"),
+                true => String::from(""),
+            },
+            normalized_combos: match trigger_defaults {
+                false => String::from("0.000=1,16.000=2,48.000=1"),
+                true => String::from(""),
+            },
             ssc_version: 0.83,
             timing_format: rssp_core::timing::TimingFormat::Ssc,
             banner_path: String::from("banner.png"),
@@ -821,21 +1267,29 @@ mod tests {
             cdtitle_path: String::from("cdtitle.png"),
             jacket_path: String::from("jacket.png"),
             music_path: String::from("music.ogg"),
-            display_bpm_str: String::from("150"), // TODO include_nonempty
+            display_bpm_str: if include_nonempty {
+                String::from("150")
+            } else {
+                Default::default()
+            },
             sample_start: 10.0,
             sample_length: 16.0,
             origin_str: String::from("Origin"),
             credit_str: String::from("Credit"),
             normalized_bgchanges: Default::default(), // TODO
-            normalized_fgchanges: Default::default(), // TODO include_nonempty
+            normalized_fgchanges: if include_nonempty {
+                Default::default() // TODO
+            } else {
+                Default::default()
+            },
             normalized_keysounds: Default::default(), // TODO
-            normalized_attacks: Default::default(),
+            normalized_attacks: Default::default(),   // TODO
             previewvid_path: String::from("previewvid.mov"),
             cdimage_path: String::from("cdimage.png"),
             discimage_path: String::from("discimage.png"),
             lyrics_path: String::from("lyrics.lrc"),
             selectable: true,
-            // last_second_hint: Some(120.0), // TODO include_nonempty
+            // last_second_hint: include_nonempty.then(|| 120.0), // TODO
 
             // To be populated by the test
             charts: vec![],
@@ -852,48 +1306,64 @@ mod tests {
         }
     }
 
-    fn chart_summary_with_all_fields(has_own_timing: bool) -> crate::ChartSummary {
+    fn chart_summary_with_all_fields(
+        has_own_timing: bool,
+        include_nonempty: bool,
+        trigger_defaults: bool,
+    ) -> crate::ChartSummary {
         crate::ChartSummary {
-            step_type_str: String::from("dance-single"),
+            step_type_str: match trigger_defaults {
+                false => String::from("dance-single"),
+                true => String::from(""),
+            },
             step_artist_str: String::from("Step artist"),
             description_str: String::from("Description"),
             chart_name_str: String::from("Chart name"),
             chart_style_str: String::from("Chart style"),
-            difficulty_str: String::from("Challenge"),
-            rating_str: String::from("17"),
+            difficulty_str: match trigger_defaults {
+                false => String::from("Challenge"),
+                true => String::from(""),
+            },
+            rating_str: match trigger_defaults {
+                false => String::from("17"),
+                true => String::from(""),
+            },
             cached_radar_values: Some([
                 0.010, 0.020, 0.030, 0.040, 0.050, 0.060, 0.070, 0.080, 0.090, 0.100, 0.110, 0.120,
                 0.130, 0.140,
             ]),
             tech_notation_str: String::from("BR FS XO"),
             minimized_note_data: b"0000\n0000\n0000\n0000\n".to_vec(), // TODO
+            music_path: match include_nonempty {
+                true => String::from("chart_music.ogg"),
+                false => String::from(""),
+            },
 
             // Timing fields
             chart_has_own_timing: has_own_timing,
-            music_path: match has_own_timing {
-                true => String::from("music.ogg"),
-                false => String::from(""),
-            },
-            chart_attacks: Default::default(), // TODO
-            chart_bpms: has_own_timing
+            chart_bpms: (has_own_timing && !trigger_defaults)
                 .then(|| String::from("0.000=120.000,16.000=240.000,48.000=120.000")),
             chart_stops: has_own_timing.then(|| String::from("1.000=1.250,1.500=1.750")),
             chart_delays: has_own_timing.then(|| String::from("2.000=2.250,2.500=2.750")),
             chart_warps: has_own_timing.then(|| String::from("3.000=3.250,3.500=3.750")),
-            chart_speeds: has_own_timing.then(|| {
+            chart_speeds: (has_own_timing && !trigger_defaults).then(|| {
                 String::from("0.000=1.000=0.000=0,12.000=0.500=4.000=0,48.000=1.000=0.000=1")
             }),
-            chart_scrolls: has_own_timing
+            chart_scrolls: (has_own_timing && !trigger_defaults)
                 .then(|| String::from("0.000=1.000,16.000=2.000,48.000=1.000")),
             chart_fakes: has_own_timing.then(|| String::from("4.000=4.250,4.500=4.750")),
-            chart_time_signatures: has_own_timing
+            chart_time_signatures: (has_own_timing && !trigger_defaults)
                 .then(|| String::from("0.000=4=4,16.000=8=4,48.000=4=4")),
-            chart_labels: has_own_timing.then(|| String::from("0.000=Song Start,16.000=Speedup")),
-            chart_tickcounts: has_own_timing.then(|| String::from("0.000=4,16.000=2,48.000=4")),
-            chart_combos: has_own_timing.then(|| String::from("0.000=1,16.000=2,48.000=1")),
-            chart_display_bpm: has_own_timing.then(|| String::from("150")),
+            chart_labels: (has_own_timing && !trigger_defaults)
+                .then(|| String::from("0.000=Song Start,16.000=Speedup")),
+            chart_tickcounts: (has_own_timing && !trigger_defaults)
+                .then(|| String::from("0.000=4,16.000=2,48.000=4")),
+            chart_combos: (has_own_timing && !trigger_defaults)
+                .then(|| String::from("0.000=1,16.000=2,48.000=1")),
+            chart_attacks: include_nonempty.then(|| Default::default()), // TODO
+            chart_display_bpm: include_nonempty.then(|| String::from("300")),
 
-            // The remaining fields are irrelevant to serialization
+            // These are currently unused in favor of the `chart_*` fields above
             timing_segments: Arc::new(crate::timing::TimingSegments {
                 beat0_offset_adjust: Default::default(),
                 bpms: Default::default(),
@@ -904,6 +1374,8 @@ mod tests {
                 scrolls: Default::default(),
                 fakes: Default::default(),
             }),
+
+            // The remaining fields are irrelevant to serialization
             matrix_rating: Default::default(),
             tier_bpm: Default::default(),
             stats: Default::default(),

--- a/crates/rssp/src/serialize.rs
+++ b/crates/rssp/src/serialize.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use rssp_core::parse::extension_is_ssc;
+use rssp_core::{parse::extension_is_ssc, timing::SpeedUnit};
 
 pub const DEFAULT_VERSION: &[u8] = b"0.83";
 pub const DEFAULT_TITLE: &[u8] = b"Untitled";
@@ -74,6 +74,8 @@ enum PropValue<'a> {
     Number(f64),
     NumberOpt(Option<f64>),
     Bool(bool),
+    TimingPairs(&'a [(f32, f32)]),
+    TimingSpeeds(&'a [(f32, f32, f32, SpeedUnit)]),
     RadarValues(Option<[f32; crate::stats::RADAR_CATEGORY_COUNT]>, bool),
 }
 
@@ -123,6 +125,48 @@ impl<'a> PropValue<'a> {
                 }
                 None => Ok(0),
             },
+            PropValue::TimingPairs(items) => {
+                let mut written_bytes = 0;
+                let mut first_item = true;
+
+                for (beat, value) in items.iter() {
+                    if !first_item {
+                        written_bytes += write_all!(out, b",\n")?;
+                    }
+                    written_bytes += write_all!(out, format_dot6_f32(*beat).as_bytes())?;
+                    written_bytes += write_all!(out, b"=")?;
+                    written_bytes += write_all!(out, format_dot6_f32(*value).as_bytes())?;
+                    first_item = false;
+                }
+
+                Ok(written_bytes)
+            }
+            PropValue::TimingSpeeds(items) => {
+                let mut written_bytes = 0;
+                let mut first_item = true;
+
+                for (beat, ratio, delay, unit) in items.iter() {
+                    if !first_item {
+                        written_bytes += write_all!(out, b",\n")?;
+                    }
+                    written_bytes += write_all!(out, format_dot6_f32(*beat).as_bytes())?;
+                    written_bytes += write_all!(out, b"=")?;
+                    written_bytes += write_all!(out, format_dot6_f32(*ratio).as_bytes())?;
+                    written_bytes += write_all!(out, b"=")?;
+                    written_bytes += write_all!(out, format_dot6_f32(*delay).as_bytes())?;
+                    written_bytes += write_all!(out, b"=")?;
+                    written_bytes += write_all!(
+                        out,
+                        match unit {
+                            SpeedUnit::Seconds => b"1",
+                            SpeedUnit::Beats => b"0",
+                        }
+                    )?;
+                    first_item = false;
+                }
+
+                Ok(written_bytes)
+            }
         }
     }
 
@@ -139,6 +183,8 @@ impl<'a> PropValue<'a> {
             PropValue::Number(_) => false,
             PropValue::NumberOpt(opt) => opt.is_none(),
             PropValue::Bool(_) => false,
+            PropValue::TimingPairs(items) => items.is_empty(),
+            PropValue::TimingSpeeds(items) => items.is_empty(),
             PropValue::RadarValues(rv, _) => rv.is_none(),
         }
     }
@@ -301,16 +347,16 @@ pub fn serialize_simfile(
         Prop::new(b"SAMPLELENGTH", PropValue::Number(summary.sample_length)),
         Prop::new(b"SELECTABLE", PropValue::Bool(summary.selectable)),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscape(&summary.display_bpm_str)),
-        Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::StrNoEscape(&summary.normalized_bpms)),
-        Prop::new(b"STOPS", PropValue::StrNoEscape(&summary.normalized_stops)),
-        Prop::ssc_only(b"DELAYS", PropValue::StrNoEscape(&summary.normalized_delays)),
-        Prop::ssc_only(b"WARPS", PropValue::StrNoEscape(&summary.normalized_warps)),
+        Prop::new_with_default(b"BPMS", DEFAULT_BPMS, PropValue::TimingPairs(&summary.global_timing_segments.bpms)),
+        Prop::new(b"STOPS", PropValue::TimingPairs(&summary.global_timing_segments.stops)),
+        Prop::ssc_only(b"DELAYS", PropValue::TimingPairs(&summary.global_timing_segments.delays)),
+        Prop::ssc_only(b"WARPS", PropValue::TimingPairs(&summary.global_timing_segments.warps)),
         Prop::ssc_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::StrNoEscape(&summary.normalized_time_signatures)),
         Prop::ssc_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::StrNoEscape(&summary.normalized_tickcounts)),
         Prop::ssc_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::StrNoEscape(&summary.normalized_combos)),
-        Prop::ssc_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::StrNoEscape(&summary.normalized_speeds)),
-        Prop::ssc_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::StrNoEscape(&summary.normalized_scrolls)),
-        Prop::ssc_only(b"FAKES", PropValue::StrNoEscape(&summary.normalized_fakes)),
+        Prop::ssc_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::TimingSpeeds(&summary.global_timing_segments.speeds)),
+        Prop::ssc_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::TimingPairs(&summary.global_timing_segments.scrolls)),
+        Prop::ssc_only(b"FAKES", PropValue::TimingPairs(&summary.global_timing_segments.fakes)),
         Prop::ssc_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::StrNoEscape(&summary.normalized_labels)),
         Prop::ssc_nonempty_only(b"LASTSECONDHINT", PropValue::NumberOpt(summary.last_second_hint)),
         Prop::new(b"BGCHANGES", PropValue::StrNoEscape(&summary.normalized_bgchanges)),
@@ -415,16 +461,16 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
         Prop::new(b"RADARVALUES", PropValue::RadarValues(chart.cached_radar_values, true)),
         Prop::new(b"CREDIT", PropValue::Str(&chart.step_artist_str)),
         Prop::own_timing_only(b"OFFSET", PropValue::Number(chart.chart_offset_seconds)),
-        Prop::own_timing_only_with_default(b"BPMS", DEFAULT_BPMS, PropValue::StrNoEscapeOpt(chart.chart_bpms.as_deref())),
-        Prop::own_timing_only(b"STOPS", PropValue::StrNoEscapeOpt(chart.chart_stops.as_deref())),
-        Prop::own_timing_only(b"DELAYS", PropValue::StrNoEscapeOpt(chart.chart_delays.as_deref())),
-        Prop::own_timing_only(b"WARPS", PropValue::StrNoEscapeOpt(chart.chart_warps.as_deref())),
+        Prop::own_timing_only_with_default(b"BPMS", DEFAULT_BPMS, PropValue::TimingPairs(&chart.timing_segments.bpms)),
+        Prop::own_timing_only(b"STOPS", PropValue::TimingPairs(&chart.timing_segments.stops)),
+        Prop::own_timing_only(b"DELAYS", PropValue::TimingPairs(&chart.timing_segments.delays)),
+        Prop::own_timing_only(b"WARPS", PropValue::TimingPairs(&chart.timing_segments.warps)),
         Prop::own_timing_only_with_default(b"TIMESIGNATURES", DEFAULT_TIME_SIGNATURES, PropValue::StrNoEscapeOpt(chart.chart_time_signatures.as_deref())),
         Prop::own_timing_only_with_default(b"TICKCOUNTS", DEFAULT_TICKCOUNTS, PropValue::StrNoEscapeOpt(chart.chart_tickcounts.as_deref())),
         Prop::own_timing_only_with_default(b"COMBOS", DEFAULT_COMBOS, PropValue::StrNoEscapeOpt(chart.chart_combos.as_deref())),
-        Prop::own_timing_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::StrNoEscapeOpt(chart.chart_speeds.as_deref())),
-        Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::StrNoEscapeOpt(chart.chart_scrolls.as_deref())),
-        Prop::own_timing_only(b"FAKES", PropValue::StrNoEscapeOpt(chart.chart_fakes.as_deref())),
+        Prop::own_timing_only_with_default(b"SPEEDS", DEFAULT_SPEEDS, PropValue::TimingSpeeds(&chart.timing_segments.speeds)),
+        Prop::own_timing_only_with_default(b"SCROLLS", DEFAULT_SCROLLS, PropValue::TimingPairs(&chart.timing_segments.scrolls)),
+        Prop::own_timing_only(b"FAKES", PropValue::TimingPairs(&chart.timing_segments.fakes)),
         Prop::own_timing_only_with_default(b"LABELS", DEFAULT_LABELS, PropValue::StrNoEscapeOpt(chart.chart_labels.as_deref())),
         Prop::nonempty_only(b"ATTACKS", PropValue::StrNoEscapeOpt(chart.chart_has_own_attacks.then(|| chart.chart_attacks.as_deref()).flatten())),
         Prop::nonempty_only(b"DISPLAYBPM", PropValue::StrNoEscapeOpt(chart.chart_display_bpm.as_deref())),
@@ -442,6 +488,7 @@ fn serialize_ssc_chart(out: &mut dyn io::Write, chart: &crate::ChartSummary) -> 
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use rssp_core::timing::TimingSegments;
     use std::io;
     use std::sync::Arc;
 
@@ -485,34 +532,34 @@ mod tests {
             #SAMPLESTART:10.000000;\n\
             #SAMPLELENGTH:16.000000;\n\
             #SELECTABLE:YES;\n\
-            #BPMS:0.000=120.000,\n\
-            16.000=240.000,\n\
-            48.000=120.000;\n\
-            #STOPS:1.000=1.250,\n\
-            1.500=1.750;\n\
-            #DELAYS:2.000=2.250,\n\
-            2.500=2.750;\n\
-            #WARPS:3.000=3.250,\n\
-            3.500=3.750;\n\
-            #TIMESIGNATURES:0.000=4=4,\n\
-            16.000=8=4,\n\
-            48.000=4=4;\n\
-            #TICKCOUNTS:0.000=4,\n\
-            16.000=2,\n\
-            48.000=4;\n\
-            #COMBOS:0.000=1,\n\
-            16.000=2,\n\
-            48.000=1;\n\
-            #SPEEDS:0.000=1.000=0.000=0,\n\
-            12.000=0.500=4.000=0,\n\
-            48.000=1.000=0.000=1;\n\
-            #SCROLLS:0.000=1.000,\n\
-            16.000=2.000,\n\
-            48.000=1.000;\n\
-            #FAKES:4.000=4.250,\n\
-            4.500=4.750;\n\
-            #LABELS:0.000=Song Start,\n\
-            16.000=Speedup;\n\
+            #BPMS:0.000000=120.000000,\n\
+            16.000000=240.000000,\n\
+            48.000000=120.000000;\n\
+            #STOPS:1.000000=1.250000,\n\
+            1.500000=1.750000;\n\
+            #DELAYS:2.000000=2.250000,\n\
+            2.500000=2.750000;\n\
+            #WARPS:3.000000=3.250000,\n\
+            3.500000=3.750000;\n\
+            #TIMESIGNATURES:0.000000=4=4,\n\
+            16.000000=8=4,\n\
+            48.000000=4=4;\n\
+            #TICKCOUNTS:0.000000=4,\n\
+            16.000000=2,\n\
+            48.000000=4;\n\
+            #COMBOS:0.000000=1,\n\
+            16.000000=2,\n\
+            48.000000=1;\n\
+            #SPEEDS:0.000000=1.000000=0.000000=0,\n\
+            12.000000=0.500000=4.000000=0,\n\
+            48.000000=1.000000=0.000000=1;\n\
+            #SCROLLS:0.000000=1.000000,\n\
+            16.000000=2.000000,\n\
+            48.000000=1.000000;\n\
+            #FAKES:4.000000=4.250000,\n\
+            4.500000=4.750000;\n\
+            #LABELS:0.000000=Song Start,\n\
+            16.000000=Speedup;\n\
             #BGCHANGES:BGChanges;\n\
             #KEYSOUNDS:;\n\
             #ATTACKS:;\n\
@@ -547,34 +594,34 @@ mod tests {
             0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
-            #BPMS:0.000=120.000,\n\
-            16.000=240.000,\n\
-            48.000=120.000;\n\
-            #STOPS:1.000=1.250,\n\
-            1.500=1.750;\n\
-            #DELAYS:2.000=2.250,\n\
-            2.500=2.750;\n\
-            #WARPS:3.000=3.250,\n\
-            3.500=3.750;\n\
-            #TIMESIGNATURES:0.000=4=4,\n\
-            16.000=8=4,\n\
-            48.000=4=4;\n\
-            #TICKCOUNTS:0.000=4,\n\
-            16.000=2,\n\
-            48.000=4;\n\
-            #COMBOS:0.000=1,\n\
-            16.000=2,\n\
-            48.000=1;\n\
-            #SPEEDS:0.000=1.000=0.000=0,\n\
-            12.000=0.500=4.000=0,\n\
-            48.000=1.000=0.000=1;\n\
-            #SCROLLS:0.000=1.000,\n\
-            16.000=2.000,\n\
-            48.000=1.000;\n\
-            #FAKES:4.000=4.250,\n\
-            4.500=4.750;\n\
-            #LABELS:0.000=Song Start,\n\
-            16.000=Speedup;\n\
+            #BPMS:0.000000=120.000000,\n\
+            116.000000=240.000000,\n\
+            148.000000=120.000000;\n\
+            #STOPS:101.000000=1.250000,\n\
+            101.500000=1.750000;\n\
+            #DELAYS:102.000000=2.250000,\n\
+            102.500000=2.750000;\n\
+            #WARPS:103.000000=3.250000,\n\
+            103.500000=3.750000;\n\
+            #TIMESIGNATURES:0.000000=4=4,\n\
+            116.000000=8=4,\n\
+            148.000000=4=4;\n\
+            #TICKCOUNTS:0.000000=4,\n\
+            116.000000=2,\n\
+            148.000000=4;\n\
+            #COMBOS:0.000000=1,\n\
+            116.000000=2,\n\
+            148.000000=1;\n\
+            #SPEEDS:0.000000=1.000000=0.000000=0,\n\
+            112.000000=0.500000=4.000000=0,\n\
+            148.000000=1.000000=0.000000=1;\n\
+            #SCROLLS:0.000000=1.000000,\n\
+            116.000000=2.000000,\n\
+            148.000000=1.000000;\n\
+            #FAKES:104.000000=4.250000,\n\
+            104.500000=4.750000;\n\
+            #LABELS:0.000000=Song Start,\n\
+            116.000000=Speedup;\n\
             #NOTES:\n\
             0000\n\
             0000\n\
@@ -629,34 +676,34 @@ mod tests {
             #SAMPLELENGTH:16.000000;\n\
             #SELECTABLE:YES;\n\
             #DISPLAYBPM:150;\n\
-            #BPMS:0.000=120.000,\n\
-            16.000=240.000,\n\
-            48.000=120.000;\n\
-            #STOPS:1.000=1.250,\n\
-            1.500=1.750;\n\
-            #DELAYS:2.000=2.250,\n\
-            2.500=2.750;\n\
-            #WARPS:3.000=3.250,\n\
-            3.500=3.750;\n\
-            #TIMESIGNATURES:0.000=4=4,\n\
-            16.000=8=4,\n\
-            48.000=4=4;\n\
-            #TICKCOUNTS:0.000=4,\n\
-            16.000=2,\n\
-            48.000=4;\n\
-            #COMBOS:0.000=1,\n\
-            16.000=2,\n\
-            48.000=1;\n\
-            #SPEEDS:0.000=1.000=0.000=0,\n\
-            12.000=0.500=4.000=0,\n\
-            48.000=1.000=0.000=1;\n\
-            #SCROLLS:0.000=1.000,\n\
-            16.000=2.000,\n\
-            48.000=1.000;\n\
-            #FAKES:4.000=4.250,\n\
-            4.500=4.750;\n\
-            #LABELS:0.000=Song Start,\n\
-            16.000=Speedup;\n\
+            #BPMS:0.000000=120.000000,\n\
+            16.000000=240.000000,\n\
+            48.000000=120.000000;\n\
+            #STOPS:1.000000=1.250000,\n\
+            1.500000=1.750000;\n\
+            #DELAYS:2.000000=2.250000,\n\
+            2.500000=2.750000;\n\
+            #WARPS:3.000000=3.250000,\n\
+            3.500000=3.750000;\n\
+            #TIMESIGNATURES:0.000000=4=4,\n\
+            16.000000=8=4,\n\
+            48.000000=4=4;\n\
+            #TICKCOUNTS:0.000000=4,\n\
+            16.000000=2,\n\
+            48.000000=4;\n\
+            #COMBOS:0.000000=1,\n\
+            16.000000=2,\n\
+            48.000000=1;\n\
+            #SPEEDS:0.000000=1.000000=0.000000=0,\n\
+            12.000000=0.500000=4.000000=0,\n\
+            48.000000=1.000000=0.000000=1;\n\
+            #SCROLLS:0.000000=1.000000,\n\
+            16.000000=2.000000,\n\
+            48.000000=1.000000;\n\
+            #FAKES:4.000000=4.250000,\n\
+            4.500000=4.750000;\n\
+            #LABELS:0.000000=Song Start,\n\
+            16.000000=Speedup;\n\
             #LASTSECONDHINT:120.000000;\n\
             #BGCHANGES:BGChanges;\n\
             #FGCHANGES:FGChanges;\n\
@@ -697,34 +744,34 @@ mod tests {
             0.010000,0.020000,0.030000,0.040000,0.050000,0.060000,0.070000,0.080000,0.090000,0.100000,0.110000,0.120000,0.130000,0.140000;\n\
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
-            #BPMS:0.000=120.000,\n\
-            16.000=240.000,\n\
-            48.000=120.000;\n\
-            #STOPS:1.000=1.250,\n\
-            1.500=1.750;\n\
-            #DELAYS:2.000=2.250,\n\
-            2.500=2.750;\n\
-            #WARPS:3.000=3.250,\n\
-            3.500=3.750;\n\
-            #TIMESIGNATURES:0.000=4=4,\n\
-            16.000=8=4,\n\
-            48.000=4=4;\n\
-            #TICKCOUNTS:0.000=4,\n\
-            16.000=2,\n\
-            48.000=4;\n\
-            #COMBOS:0.000=1,\n\
-            16.000=2,\n\
-            48.000=1;\n\
-            #SPEEDS:0.000=1.000=0.000=0,\n\
-            12.000=0.500=4.000=0,\n\
-            48.000=1.000=0.000=1;\n\
-            #SCROLLS:0.000=1.000,\n\
-            16.000=2.000,\n\
-            48.000=1.000;\n\
-            #FAKES:4.000=4.250,\n\
-            4.500=4.750;\n\
-            #LABELS:0.000=Song Start,\n\
-            16.000=Speedup;\n\
+            #BPMS:0.000000=120.000000,\n\
+            116.000000=240.000000,\n\
+            148.000000=120.000000;\n\
+            #STOPS:101.000000=1.250000,\n\
+            101.500000=1.750000;\n\
+            #DELAYS:102.000000=2.250000,\n\
+            102.500000=2.750000;\n\
+            #WARPS:103.000000=3.250000,\n\
+            103.500000=3.750000;\n\
+            #TIMESIGNATURES:0.000000=4=4,\n\
+            116.000000=8=4,\n\
+            148.000000=4=4;\n\
+            #TICKCOUNTS:0.000000=4,\n\
+            116.000000=2,\n\
+            148.000000=4;\n\
+            #COMBOS:0.000000=1,\n\
+            116.000000=2,\n\
+            148.000000=1;\n\
+            #SPEEDS:0.000000=1.000000=0.000000=0,\n\
+            112.000000=0.500000=4.000000=0,\n\
+            148.000000=1.000000=0.000000=1;\n\
+            #SCROLLS:0.000000=1.000000,\n\
+            116.000000=2.000000,\n\
+            148.000000=1.000000;\n\
+            #FAKES:104.000000=4.250000,\n\
+            104.500000=4.750000;\n\
+            #LABELS:0.000000=Song Start,\n\
+            116.000000=Speedup;\n\
             #ATTACKS:Attacks;\n\
             #DISPLAYBPM:300;\n\
             #NOTES:\n\
@@ -781,19 +828,15 @@ mod tests {
             #SAMPLELENGTH:16.000000;\n\
             #SELECTABLE:YES;\n\
             #BPMS:0.000000=60.000000;\n\
-            #STOPS:1.000=1.250,\n\
-            1.500=1.750;\n\
-            #DELAYS:2.000=2.250,\n\
-            2.500=2.750;\n\
-            #WARPS:3.000=3.250,\n\
-            3.500=3.750;\n\
+            #STOPS:;\n\
+            #DELAYS:;\n\
+            #WARPS:;\n\
             #TIMESIGNATURES:0.000000=4=4;\n\
             #TICKCOUNTS:0.000000=4;\n\
             #COMBOS:0.000000=1;\n\
             #SPEEDS:0.000000=1.000000=0.000000=0;\n\
             #SCROLLS:0.000000=1.000000;\n\
-            #FAKES:4.000=4.250,\n\
-            4.500=4.750;\n\
+            #FAKES:;\n\
             #LABELS:0.000000=Song Start;\n\
             #BGCHANGES:BGChanges;\n\
             #KEYSOUNDS:;\n\
@@ -830,19 +873,15 @@ mod tests {
             #CREDIT:Step artist;\n\
             #OFFSET:0.000000;\n\
             #BPMS:0.000000=60.000000;\n\
-            #STOPS:1.000=1.250,\n\
-            1.500=1.750;\n\
-            #DELAYS:2.000=2.250,\n\
-            2.500=2.750;\n\
-            #WARPS:3.000=3.250,\n\
-            3.500=3.750;\n\
+            #STOPS:;\n\
+            #DELAYS:;\n\
+            #WARPS:;\n\
             #TIMESIGNATURES:0.000000=4=4;\n\
             #TICKCOUNTS:0.000000=4;\n\
             #COMBOS:0.000000=1;\n\
             #SPEEDS:0.000000=1.000000=0.000000=0;\n\
             #SCROLLS:0.000000=1.000000;\n\
-            #FAKES:4.000=4.250,\n\
-            4.500=4.750;\n\
+            #FAKES:;\n\
             #LABELS:0.000000=Song Start;\n\
             #NOTES:\n\
             0000\n\
@@ -889,11 +928,11 @@ mod tests {
         #SAMPLESTART:10.000000;\n\
         #SAMPLELENGTH:16.000000;\n\
         #SELECTABLE:YES;\n\
-        #BPMS:0.000=120.000,\n\
-        16.000=240.000,\n\
-        48.000=120.000;\n\
-        #STOPS:1.000=1.250,\n\
-        1.500=1.750;\n\
+        #BPMS:0.000000=120.000000,\n\
+        16.000000=240.000000,\n\
+        48.000000=120.000000;\n\
+        #STOPS:1.000000=1.250000,\n\
+        1.500000=1.750000;\n\
         #BGCHANGES:BGChanges;\n\
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
@@ -945,11 +984,11 @@ mod tests {
         #SAMPLELENGTH:16.000000;\n\
         #SELECTABLE:YES;\n\
         #DISPLAYBPM:150;\n\
-        #BPMS:0.000=120.000,\n\
-        16.000=240.000,\n\
-        48.000=120.000;\n\
-        #STOPS:1.000=1.250,\n\
-        1.500=1.750;\n\
+        #BPMS:0.000000=120.000000,\n\
+        16.000000=240.000000,\n\
+        48.000000=120.000000;\n\
+        #STOPS:1.000000=1.250000,\n\
+        1.500000=1.750000;\n\
         #BGCHANGES:BGChanges;\n\
         #FGCHANGES:FGChanges;\n\
         #KEYSOUNDS:;\n\
@@ -1002,8 +1041,7 @@ mod tests {
         #SAMPLELENGTH:16.000000;\n\
         #SELECTABLE:YES;\n\
         #BPMS:0.000000=60.000000;\n\
-        #STOPS:1.000=1.250,\n\
-        1.500=1.750;\n\
+        #STOPS:;\n\
         #BGCHANGES:BGChanges;\n\
         #KEYSOUNDS:;\n\
         #ATTACKS:;\n\
@@ -1061,39 +1099,50 @@ mod tests {
             subtitletranslit_str: String::from("Subtitle translit"),
             artisttranslit_str: String::from("Artist translit"),
             offset: 0.123,
-            normalized_bpms: match trigger_defaults {
-                false => String::from("0.000=120.000,\n16.000=240.000,\n48.000=120.000"),
-                true => String::from(""),
+            normalized_bpms: Default::default(),
+            normalized_stops: Default::default(),
+            normalized_delays: Default::default(),
+            normalized_warps: Default::default(),
+            normalized_speeds: Default::default(),
+            normalized_scrolls: Default::default(),
+            normalized_fakes: Default::default(),
+            global_timing_segments: if trigger_defaults {
+                Arc::new(TimingSegments::default())
+            } else {
+                Arc::new(TimingSegments {
+                    beat0_offset_adjust: Default::default(),
+                    bpms: vec![(0.000, 120.000), (16.000, 240.000), (48.000, 120.000)],
+                    stops: vec![(1.000, 1.250), (1.500, 1.750)],
+                    delays: vec![(2.000, 2.250), (2.500, 2.750)],
+                    warps: vec![(3.000, 3.250), (3.500, 3.750)],
+                    speeds: vec![
+                        (0.000, 1.000, 0.000, rssp_core::timing::SpeedUnit::Beats),
+                        (12.000, 0.500, 4.000, rssp_core::timing::SpeedUnit::Beats),
+                        (48.000, 1.000, 0.000, rssp_core::timing::SpeedUnit::Seconds),
+                    ],
+                    scrolls: vec![(0.000, 1.000), (16.000, 2.000), (48.000, 1.000)],
+                    fakes: vec![(4.000, 4.250), (4.500, 4.750)],
+                })
             },
-            normalized_stops: String::from("1.000=1.250,\n1.500=1.750"),
-            normalized_delays: String::from("2.000=2.250,\n2.500=2.750"),
-            normalized_warps: String::from("3.000=3.250,\n3.500=3.750"),
-            normalized_speeds: match trigger_defaults {
-                false => String::from(
-                    "0.000=1.000=0.000=0,\n12.000=0.500=4.000=0,\n48.000=1.000=0.000=1",
-                ),
-                true => String::from(""),
+            normalized_time_signatures: if trigger_defaults {
+                String::from("")
+            } else {
+                String::from("0.000000=4=4,\n16.000000=8=4,\n48.000000=4=4")
             },
-            normalized_scrolls: match trigger_defaults {
-                false => String::from("0.000=1.000,\n16.000=2.000,\n48.000=1.000"),
-                true => String::from(""),
+            normalized_labels: if trigger_defaults {
+                String::from("")
+            } else {
+                String::from("0.000000=Song Start,\n16.000000=Speedup")
             },
-            normalized_fakes: String::from("4.000=4.250,\n4.500=4.750"),
-            normalized_time_signatures: match trigger_defaults {
-                false => String::from("0.000=4=4,\n16.000=8=4,\n48.000=4=4"),
-                true => String::from(""),
+            normalized_tickcounts: if trigger_defaults {
+                String::from("")
+            } else {
+                String::from("0.000000=4,\n16.000000=2,\n48.000000=4")
             },
-            normalized_labels: match trigger_defaults {
-                false => String::from("0.000=Song Start,\n16.000=Speedup"),
-                true => String::from(""),
-            },
-            normalized_tickcounts: match trigger_defaults {
-                false => String::from("0.000=4,\n16.000=2,\n48.000=4"),
-                true => String::from(""),
-            },
-            normalized_combos: match trigger_defaults {
-                false => String::from("0.000=1,\n16.000=2,\n48.000=1"),
-                true => String::from(""),
+            normalized_combos: if trigger_defaults {
+                String::from("")
+            } else {
+                String::from("0.000000=1,\n16.000000=2,\n48.000000=1")
             },
             ssc_version: 0.83,
             timing_format: rssp_core::timing::TimingFormat::Ssc,
@@ -1180,39 +1229,45 @@ mod tests {
 
             // Timing fields
             chart_has_own_timing: has_own_timing,
-            chart_bpms: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=120.000,\n16.000=240.000,\n48.000=120.000")),
-            chart_stops: has_own_timing.then(|| String::from("1.000=1.250,\n1.500=1.750")),
-            chart_delays: has_own_timing.then(|| String::from("2.000=2.250,\n2.500=2.750")),
-            chart_warps: has_own_timing.then(|| String::from("3.000=3.250,\n3.500=3.750")),
-            chart_speeds: (has_own_timing && !trigger_defaults).then(|| {
-                String::from("0.000=1.000=0.000=0,\n12.000=0.500=4.000=0,\n48.000=1.000=0.000=1")
-            }),
-            chart_scrolls: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=1.000,\n16.000=2.000,\n48.000=1.000")),
-            chart_fakes: has_own_timing.then(|| String::from("4.000=4.250,\n4.500=4.750")),
             chart_time_signatures: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=4=4,\n16.000=8=4,\n48.000=4=4")),
+                .then(|| String::from("0.000000=4=4,\n116.000000=8=4,\n148.000000=4=4")),
             chart_labels: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=Song Start,\n16.000=Speedup")),
+                .then(|| String::from("0.000000=Song Start,\n116.000000=Speedup")),
             chart_tickcounts: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=4,\n16.000=2,\n48.000=4")),
+                .then(|| String::from("0.000000=4,\n116.000000=2,\n148.000000=4")),
             chart_combos: (has_own_timing && !trigger_defaults)
-                .then(|| String::from("0.000=1,\n16.000=2,\n48.000=1")),
+                .then(|| String::from("0.000000=1,\n116.000000=2,\n148.000000=1")),
             chart_attacks: include_nonempty.then(|| String::from("Attacks")), // TODO
+            chart_has_own_attacks: include_nonempty,
             chart_display_bpm: include_nonempty.then(|| String::from("300")),
 
-            // These are currently unused in favor of the `chart_*` fields above
-            timing_segments: Arc::new(crate::timing::TimingSegments {
-                beat0_offset_adjust: Default::default(),
-                bpms: Default::default(),
-                stops: Default::default(),
-                delays: Default::default(),
-                warps: Default::default(),
-                speeds: Default::default(),
-                scrolls: Default::default(),
-                fakes: Default::default(),
-            }),
+            timing_segments: if has_own_timing && !trigger_defaults {
+                Arc::new(TimingSegments {
+                    beat0_offset_adjust: Default::default(),
+                    bpms: vec![(0.000, 120.000), (116.000, 240.000), (148.000, 120.000)],
+                    stops: vec![(101.000, 1.250), (101.500, 1.750)],
+                    delays: vec![(102.000, 2.250), (102.500, 2.750)],
+                    warps: vec![(103.000, 3.250), (103.500, 3.750)],
+                    speeds: vec![
+                        (0.000, 1.000, 0.000, rssp_core::timing::SpeedUnit::Beats),
+                        (112.000, 0.500, 4.000, rssp_core::timing::SpeedUnit::Beats),
+                        (148.000, 1.000, 0.000, rssp_core::timing::SpeedUnit::Seconds),
+                    ],
+                    scrolls: vec![(0.000, 1.000), (116.000, 2.000), (148.000, 1.000)],
+                    fakes: vec![(104.000, 4.250), (104.500, 4.750)],
+                })
+            } else {
+                Arc::new(TimingSegments::default())
+            },
+
+            // Unused string timing fields (TimingSegments used instead)
+            chart_bpms: Default::default(),
+            chart_stops: Default::default(),
+            chart_delays: Default::default(),
+            chart_warps: Default::default(),
+            chart_speeds: Default::default(),
+            chart_scrolls: Default::default(),
+            chart_fakes: Default::default(),
 
             // The remaining fields are irrelevant to serialization
             matrix_rating: Default::default(),

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -3,16 +3,19 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread::sleep;
-use std::time::Duration;
 
 use libtest_mimic::Arguments;
+use rssp::parse::extension_is_ssc;
 use walkdir::WalkDir;
 
 use rssp::report::{TimingSnapshot, build_timing_snapshot};
 use rssp::serialize::*;
 use rssp::stats::RADAR_CATEGORY_COUNT;
 use rssp::{AnalysisOptions, ChartSummary, SimfileSummary, analyze};
+
+pub const NORM_DEFAULT_BPMS: &[u8] = b"0.000=60.000";
+pub const NORM_DEFAULT_SPEEDS: &[u8] = b"0.000=1.000=0.000=0";
+pub const NORM_DEFAULT_SCROLLS: &[u8] = b"0.000=1.000";
 
 #[derive(Debug, Clone)]
 struct TestCase {
@@ -189,15 +192,53 @@ macro_rules! build_comparison_entry_opt {
     };
 }
 
+fn normalized_eq(a: &str, b: &str) -> bool {
+    let mut a_lines = a.lines();
+    let mut b_lines = b.lines();
+    for (line_a, line_b) in a_lines.by_ref().zip(b_lines.by_ref()) {
+        if line_a != line_b {
+            return false;
+        }
+    }
+    if a_lines.next().is_some() || b_lines.next().is_some() {
+        return false;
+    }
+    true
+}
+
+macro_rules! build_normalized_comparison_entry {
+    ($field: ident, $expected: expr, $actual: expr) => {
+        (
+            stringify!($field),
+            &$expected.$field,
+            &$actual.$field,
+            normalized_eq(&$expected.$field, &$actual.$field),
+            None,
+        )
+    };
+    ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
+        (
+            stringify!($field),
+            &$expected.$field,
+            &$actual.$field,
+            normalized_eq(&$expected.$field, &$actual.$field)
+                || ($expected.$field.is_empty() && $actual.$field.as_bytes() == $default),
+            Some($default),
+        )
+    };
+}
+
 fn compare_simfile_str_fields(
     path: &Path,
+    extension: &str,
     expected: &SimfileSummary,
     actual: &SimfileSummary,
 ) -> Result<(), String> {
+    let is_ssc = extension_is_ssc(extension).map_err(|e| e.to_string())?;
     let expected_ssc_version_display = format!("{:.2}", expected.ssc_version);
     let actual_ssc_version_display = format!("{:.2}", actual.ssc_version);
 
-    let comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
+    let mut comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
         build_comparison_entry!(title_str, expected, actual, DEFAULT_TITLE),
         build_comparison_entry!(subtitle_str, expected, actual),
         build_comparison_entry!(artist_str, expected, actual, DEFAULT_ARTIST),
@@ -206,43 +247,105 @@ fn compare_simfile_str_fields(
         build_comparison_entry!(artisttranslit_str, expected, actual),
         build_comparison_entry!(display_bpm_str, expected, actual),
         build_comparison_entry!(credit_str, expected, actual),
-        build_comparison_entry!(origin_str, expected, actual),
         build_comparison_entry!(genre_str, expected, actual),
         build_comparison_entry!(lyrics_path, expected, actual),
-        build_comparison_entry!(discimage_path, expected, actual),
-        build_comparison_entry!(cdimage_path, expected, actual),
-        build_comparison_entry!(previewvid_path, expected, actual),
         build_comparison_entry!(music_path, expected, actual),
-        build_comparison_entry!(jacket_path, expected, actual),
         build_comparison_entry!(cdtitle_path, expected, actual),
         build_comparison_entry!(background_path, expected, actual),
         build_comparison_entry!(banner_path, expected, actual),
-        build_comparison_entry!(normalized_bpms, expected, actual, DEFAULT_BPMS),
-        build_comparison_entry!(normalized_stops, expected, actual),
-        build_comparison_entry!(normalized_delays, expected, actual),
-        build_comparison_entry!(normalized_speeds, expected, actual, DEFAULT_SPEEDS),
-        build_comparison_entry!(normalized_scrolls, expected, actual, DEFAULT_SCROLLS),
-        build_comparison_entry!(normalized_fakes, expected, actual),
-        build_comparison_entry!(
+    ];
+    if is_ssc {
+        comparison_table.extend_from_slice(&[
+            build_comparison_entry!(origin_str, expected, actual),
+            build_comparison_entry!(discimage_path, expected, actual),
+            build_comparison_entry!(cdimage_path, expected, actual),
+            build_comparison_entry!(previewvid_path, expected, actual),
+            build_comparison_entry!(jacket_path, expected, actual),
+            (
+                "ssc_version",
+                &expected_ssc_version_display,
+                &actual_ssc_version_display,
+                expected.ssc_version == actual.ssc_version,
+                Some(DEFAULT_VERSION),
+            ),
+        ]);
+    }
+
+    let all_ok = comparison_table.iter().all(|entry| entry.3);
+
+    if all_ok {
+        return Ok(());
+    }
+
+    // Build error string
+    let mut buffer = vec![];
+    {
+        let mut cursor = io::Cursor::new(&mut buffer);
+        for (field_name, expected, actual, cmp, _) in comparison_table {
+            writeln!(
+                &mut cursor,
+                "  {}: baseline: {:?} -> reencoded: {:?} {}",
+                field_name,
+                expected,
+                actual,
+                match cmp {
+                    true => "....ok",
+                    false => "....MISMATCH",
+                }
+            )
+            .map_err(|e| e.to_string())?;
+        }
+    } // Drop cursor
+
+    let err_output = String::from_utf8(buffer).unwrap();
+
+    Err(format!(
+        "\n\nMISMATCH DETECTED\nFile: {}\n{}",
+        path.display(),
+        err_output,
+    ))
+}
+
+fn compare_simfile_normalized_fields(
+    path: &Path,
+    expected: &SimfileSummary,
+    actual: &SimfileSummary,
+) -> Result<(), String> {
+    let comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
+        build_normalized_comparison_entry!(normalized_bpms, expected, actual, NORM_DEFAULT_BPMS),
+        build_normalized_comparison_entry!(normalized_stops, expected, actual),
+        build_normalized_comparison_entry!(normalized_delays, expected, actual),
+        build_normalized_comparison_entry!(
+            normalized_speeds,
+            expected,
+            actual,
+            NORM_DEFAULT_SPEEDS
+        ),
+        build_normalized_comparison_entry!(
+            normalized_scrolls,
+            expected,
+            actual,
+            NORM_DEFAULT_SCROLLS
+        ),
+        build_normalized_comparison_entry!(normalized_fakes, expected, actual),
+        build_normalized_comparison_entry!(
             normalized_time_signatures,
             expected,
             actual,
             DEFAULT_TIME_SIGNATURES
         ),
-        build_comparison_entry!(normalized_labels, expected, actual, DEFAULT_LABELS),
-        build_comparison_entry!(normalized_tickcounts, expected, actual, DEFAULT_TICKCOUNTS),
-        build_comparison_entry!(normalized_combos, expected, actual, DEFAULT_COMBOS),
-        build_comparison_entry!(normalized_bgchanges, expected, actual),
-        build_comparison_entry!(normalized_fgchanges, expected, actual),
-        build_comparison_entry!(normalized_keysounds, expected, actual),
-        build_comparison_entry!(normalized_attacks, expected, actual),
-        (
-            "ssc_version",
-            &expected_ssc_version_display,
-            &actual_ssc_version_display,
-            expected.ssc_version == actual.ssc_version,
-            Some(DEFAULT_VERSION),
+        build_normalized_comparison_entry!(normalized_labels, expected, actual, DEFAULT_LABELS),
+        build_normalized_comparison_entry!(
+            normalized_tickcounts,
+            expected,
+            actual,
+            DEFAULT_TICKCOUNTS
         ),
+        build_normalized_comparison_entry!(normalized_combos, expected, actual, DEFAULT_COMBOS),
+        build_normalized_comparison_entry!(normalized_bgchanges, expected, actual),
+        build_normalized_comparison_entry!(normalized_fgchanges, expected, actual),
+        build_normalized_comparison_entry!(normalized_keysounds, expected, actual),
+        build_normalized_comparison_entry!(normalized_attacks, expected, actual),
     ];
 
     let all_ok = comparison_table.iter().all(|entry| entry.3);
@@ -258,7 +361,7 @@ fn compare_simfile_str_fields(
         for (field_name, expected, actual, cmp, _) in comparison_table {
             writeln!(
                 &mut cursor,
-                "  {}: baseline: {} -> reencoded: {} {}",
+                "  {}: baseline: {:?} -> reencoded: {:?} {}",
                 field_name,
                 expected,
                 actual,
@@ -359,7 +462,7 @@ fn compare_chart_str_fields_and_hashes(
                     for (field_name, expected, actual, cmp, _) in comparison_table {
                         writeln!(
                             &mut cursor,
-                            "  {}: baseline: {} -> reencoded: {} {}",
+                            "  {}: baseline: {:?} -> reencoded: {:?} {}",
                             field_name,
                             expected,
                             actual,
@@ -583,25 +686,24 @@ fn compare_timing(
                 }
 
                 // Build error string
-                let mut buffer = vec![];
-                {
-                    let mut cursor = io::Cursor::new(&mut buffer);
-                    for (field_name, matches) in timing_comparison_table {
-                        writeln!(
-                            &mut cursor,
-                            "  {}: {}",
-                            field_name,
-                            match matches {
-                                true => "....ok",
-                                false => "....MISMATCH",
-                            }
-                        )
-                        .map_err(|e| e.to_string())?;
-                    }
-                } // Drop cursor
+                let mut error = String::new();
+                for (field_name, matches) in timing_comparison_table {
+                    error += &format!(
+                        "  {}: {}",
+                        field_name,
+                        match matches {
+                            true => "....ok",
+                            false => "....MISMATCH",
+                        }
+                    );
+                }
 
-                let err_output = String::from_utf8(buffer).unwrap();
-                errors.push(err_output);
+                error += &format!(
+                    "\nExpected: {:?}\nActual: {:?}\n",
+                    expected_timing, actual_timing
+                );
+
+                errors.push(error);
             }
         }
     }
@@ -651,21 +753,20 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
         serialize_simfile(&base_summary, extension, &mut cursor).map_err(|e| e.to_string())?;
     };
 
-    // for chart in &base_summary.charts {
-    //     if chart.bpm_neutral_hash == "a5830d9474451c26" {
-    //         unsafe {
-    //             eprintln!("{}", String::from_utf8_unchecked(buffer.clone()));
-    //             sleep(Duration::from_secs(1));
-    //         }
-    //     }
-    // }
-
     // Re-run rssp analyze on the serialized simfile
     let reencoded_summary = run_rssp_analyze(&buffer, extension)?;
 
     println!("File: {}", path.display());
 
-    compare_simfile_str_fields(path, &base_summary, &reencoded_summary)?;
+    // let result = String::from_utf8(buffer);
+    // match result {
+    //     Ok(buffer_str) => println!("{}", buffer_str),
+    //     Err(_) => println!("debug failed"),
+    // }
+    // println!("{:?}", base_summary);
+
+    compare_simfile_str_fields(path, extension, &base_summary, &reencoded_summary)?;
+    compare_simfile_normalized_fields(path, &base_summary, &reencoded_summary)?;
     compare_chart_str_fields_and_hashes(path, &base_summary.charts, &reencoded_summary.charts)?;
     compare_chart_timing_fields(path, &base_summary.charts, &reencoded_summary.charts)?;
     compare_timing(path, &base_summary, &reencoded_summary)?;

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -360,7 +360,6 @@ fn has_misrounded_bpm_beats(normalized_bpms: &str) -> bool {
                     let tick = (decimal * 48.0 / 1000.0).round();
                     let normalized_decimal = (tick * 1000.0 / 48.0).round();
                     if normalized_decimal != decimal {
-                        print!("{:?} != {:?}", normalized_decimal, decimal);
                         return true;
                     }
                 }

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use libtest_mimic::Arguments;
+use pretty_assertions::Comparison;
 use walkdir::WalkDir;
 
 use rssp::parse::extension_is_ssc;
@@ -13,9 +14,17 @@ use rssp::stats::RADAR_CATEGORY_COUNT;
 use rssp::timing::{SpeedUnit, TimingSegments};
 use rssp::{AnalysisOptions, ChartSummary, SimfileSummary, analyze};
 
+// These are identical to the serialized defaults,
+// but truncated from 6-decimal to 3-decimal.
 pub const NORM_DEFAULT_BPMS: &[u8] = b"0.000=60.000";
 pub const NORM_DEFAULT_SPEEDS: &[u8] = b"0.000=1.000=0.000=0";
 pub const NORM_DEFAULT_SCROLLS: &[u8] = b"0.000=1.000";
+// These fields are not actually normalized in any discernible way,
+// so the default value that's serialized is then parsed exactly.
+pub const NORM_DEFAULT_TIME_SIGNATURES: &[u8] = DEFAULT_TIME_SIGNATURES;
+pub const NORM_DEFAULT_LABELS: &[u8] = DEFAULT_LABELS;
+pub const NORM_DEFAULT_TICKCOUNTS: &[u8] = DEFAULT_TICKCOUNTS;
+pub const NORM_DEFAULT_COMBOS: &[u8] = DEFAULT_COMBOS;
 pub const TIMING_DEFAULT_BPMS: &[(f32, f32)] = &[(0.0f32, 60.0f32)];
 pub const TIMING_DEFAULT_SPEEDS: &[(f32, f32, f32, SpeedUnit)] =
     &[(0.0f32, 1.0f32, 0.0f32, SpeedUnit::Beats)];
@@ -31,13 +40,20 @@ struct TestCase {
 #[derive(Debug, Clone)]
 struct Failure {
     name: String,
+    path: String,
     message: String,
 }
 
 const TIMING_EPS: f32 = 1e-3;
+// Allow beats to be off by half of a 192nd note (48 beat subdivisions).
+const NORMALIZED_BEAT_EPS: f32 = 1.0 / 96.0;
 
 fn timing_approx_eq(a: &f32, b: &f32) -> bool {
     (a - b).abs() <= TIMING_EPS
+}
+
+fn normalized_beat_approx_eq(a: &f32, b: &f32) -> bool {
+    (a - b).abs() <= NORMALIZED_BEAT_EPS
 }
 
 fn radar_values_eq(
@@ -58,6 +74,9 @@ fn radar_values_eq(
     }
 }
 
+// Compare expected.field to actual.field using the eq_fn,
+// as well as the is_default_fn if provided.
+// If neither is true, append a comparison to the error string.
 macro_rules! compare_fields {
     ($errors: expr, $expected: expr, $actual: expr, $eq_fn: ident, $field: ident) => {
         compare_fields!($errors, $expected, $actual, $eq_fn, $field, (|_, _| false))
@@ -71,6 +90,24 @@ macro_rules! compare_fields {
                 stringify!($field),
                 $expected.$field,
                 $actual.$field,
+            );
+        })
+    };
+}
+
+// Same as compare_fields!, but use a colored multiline comparison for mismatches.
+macro_rules! compare_fields_ml {
+    ($errors: expr, $expected: expr, $actual: expr, $eq_fn: ident, $field: ident) => {
+        compare_fields_ml!($errors, $expected, $actual, $eq_fn, $field, (|_, _| false))
+    };
+    ($errors: expr, $expected: expr, $actual: expr, $eq_fn: ident, $field: ident, $is_default_fn: expr) => {
+        (if !$eq_fn(&$expected.$field, &$actual.$field)
+            && !$is_default_fn(&$expected.$field, &$actual.$field)
+        {
+            $errors += &format!(
+                "{}: baseline -> reencoded ....MISMATCH\n{}\n",
+                stringify!($field),
+                Comparison::new(&$expected.$field, &$actual.$field),
             );
         })
     };
@@ -113,15 +150,102 @@ fn version_eq(expected: &f32, actual: &f32) -> bool {
     expected_str == actual_str
 }
 
-fn normalized_eq(expected: &str, actual: &str) -> bool {
-    let mut a_lines = expected.lines();
-    let mut b_lines = actual.lines();
-    for (line_a, line_b) in a_lines.by_ref().zip(b_lines.by_ref()) {
-        if line_a != line_b {
-            return false;
+// Compare rows as strings; if that fails, try breaking them out into beats & values
+// and comparing those with some leniency.
+// Beats get more leniency because the engine coerces them to 192nd ticks.
+fn normalized_beat_value_eq(expected: &str, actual: &str) -> bool {
+    let mut a_rows = expected.split(",");
+    let mut b_rows = actual.split(",");
+    for (row_a, row_b) in a_rows.by_ref().zip(b_rows.by_ref()) {
+        // Start with a simple check
+        if row_a != row_b {
+            // Try parsing the floats instead
+            if let (Some((beat_a, value_a)), Some((beat_b, value_b))) =
+                (row_a.split_once('='), row_b.split_once('='))
+            {
+                if let (Ok(ba), Ok(bb), Ok(va), Ok(vb)) = (
+                    beat_a.parse::<f32>(),
+                    beat_b.parse::<f32>(),
+                    value_a.parse::<f32>(),
+                    value_b.parse::<f32>(),
+                ) {
+                    if !normalized_beat_approx_eq(&ba, &bb) || !timing_approx_eq(&va, &vb) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
         }
     }
-    if a_lines.next().is_some() || b_lines.next().is_some() {
+    if a_rows.next().is_some() || b_rows.next().is_some() {
+        return false;
+    }
+    true
+}
+
+// Like `normalized_beat_value_eq`, but compare the values as opaque strings.
+fn normalized_beat_str_eq(expected: &str, actual: &str) -> bool {
+    let mut a_rows = expected.split(",");
+    let mut b_rows = actual.split(",");
+    for (row_a, row_b) in a_rows.by_ref().zip(b_rows.by_ref()) {
+        // Start with a simple check
+        if row_a != row_b {
+            // Try parsing the floats instead
+            if let (Some((beat_a, value_a)), Some((beat_b, value_b))) =
+                (row_a.split_once('='), row_b.split_once('='))
+            {
+                if let (Ok(ba), Ok(bb)) = (beat_a.parse::<f32>(), beat_b.parse::<f32>()) {
+                    if !normalized_beat_approx_eq(&ba, &bb) && value_a != value_b {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+    if a_rows.next().is_some() || b_rows.next().is_some() {
+        return false;
+    }
+    true
+}
+
+// Like `normalized_beat_value_eq`, but compare both the beats and values with beat-level precision.
+// Used for warps and fakes.
+fn normalized_beat_beat_eq(expected: &str, actual: &str) -> bool {
+    let mut a_rows = expected.split(",");
+    let mut b_rows = actual.split(",");
+    for (row_a, row_b) in a_rows.by_ref().zip(b_rows.by_ref()) {
+        // Start with a simple check
+        if row_a != row_b {
+            // Try parsing the floats instead
+            if let (Some((beat_a, value_a)), Some((beat_b, value_b))) =
+                (row_a.split_once('='), row_b.split_once('='))
+            {
+                if let (Ok(ba), Ok(bb), Ok(va), Ok(vb)) = (
+                    beat_a.parse::<f32>(),
+                    beat_b.parse::<f32>(),
+                    value_a.parse::<f32>(),
+                    value_b.parse::<f32>(),
+                ) {
+                    if !normalized_beat_approx_eq(&ba, &bb) || !normalized_beat_approx_eq(&va, &vb)
+                    {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+    if a_rows.next().is_some() || b_rows.next().is_some() {
         return false;
     }
     true
@@ -129,18 +253,18 @@ fn normalized_eq(expected: &str, actual: &str) -> bool {
 
 fn normalized_opt_eq(expected: &Option<String>, actual: &Option<String>) -> bool {
     match (expected, actual) {
-        (Some(a), Some(b)) => normalized_eq(a, b),
+        (Some(a), Some(b)) => normalized_beat_value_eq(a, b),
         (None, None) => true,
         _ => false,
     }
 }
 
 fn is_default_str(default: &[u8]) -> impl Fn(&str, &str) -> bool {
-    move |a, b| a.is_empty() && b.as_bytes() == default
+    move |e, a| e.is_empty() && a.as_bytes() == default
 }
 
 fn is_default_version(default: f32) -> impl Fn(&f32, &f32) -> bool {
-    move |a, b| !a.is_finite() && *b == default
+    move |e, a| !e.is_finite() && *a == default
 }
 
 fn is_default_bytes_opt(default: &[u8]) -> impl Fn(&Option<String>, &Option<String>) -> bool {
@@ -160,10 +284,11 @@ fn is_default_speeds(
     move |e, a| e.is_empty() && a == &default
 }
 
-// StepMania and DeadSync both strip certain BPMs during parsing,
-// which will inevitably change the normalized BPMs and chart hashes after serializing.
-// Use this function to determine when to ignore changes to those fields.
-fn has_hash_breaking_bpms(normalized_bpms: &str) -> bool {
+// SM and DS both skip BPMs that have a value of zero
+// or duplicate the previous BPM's beat or value.
+// This can only be verified using the normalized_bpms
+// since those BPMs are removed from the timing data.
+fn has_noop_bpms(normalized_bpms: &str) -> bool {
     let mut previous_beat: &str = "";
     let mut previous_value: &str = "";
     for pair in normalized_bpms.split(",") {
@@ -180,24 +305,141 @@ fn has_hash_breaking_bpms(normalized_bpms: &str) -> bool {
     false
 }
 
-#[inline(always)]
-fn has_warp_hacks(is_ssc: bool, timing_segments: &TimingSegments) -> bool {
-    !is_ssc && !timing_segments.warps.is_empty()
+// Similar to `has_noop_bpms`, except a scroll value of 0 is valid.
+fn has_noop_scrolls(normalized_scrolls: &str) -> bool {
+    let mut previous_beat: &str = "";
+    let mut previous_value: &str = "";
+    for pair in normalized_scrolls.split(",") {
+        if let Some((beat, value)) = pair.split_once('=') {
+            if beat == previous_beat || value == previous_value {
+                return true;
+            }
+            previous_beat = beat;
+            previous_value = value;
+        }
+    }
+    false
 }
 
+// Negative BPMs are converted to warps internally,
+// but when writing to SM, they'll be converted to negative stops.
+// Like no-op BPMs, they can only be detected in the normalized_bpms.
+fn has_negative_bpms(normalized_bpms: &str) -> bool {
+    for pair in normalized_bpms.split(",") {
+        if let Some((_, value)) = pair.split_once('=') {
+            if value.chars().next() == Some('-') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// Large (>8,192) BPMs can't encode every 3-decimal value using 32-bit floats,
+// so they might break hash after serialization.
+// This can be resolved in the future by storing 64-bit floats in the timing data
+// and converting to 32-bit on the game side for engine parity.
+fn has_large_bpms(normalized_bpms: &str) -> bool {
+    for pair in normalized_bpms.split(",") {
+        if let Some((_, value)) = pair.split_once('=') {
+            if let Ok(value_f) = value.parse::<f64>() {
+                if value_f > 8192.0 {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn has_misrounded_bpm_beats(normalized_bpms: &str) -> bool {
+    for pair in normalized_bpms.split(",") {
+        if let Some((beat, _)) = pair.split_once('=') {
+            if let Some((_, decimal)) = beat.split_once('.') {
+                if let Ok(decimal) = decimal.parse::<f64>() {
+                    let tick = (decimal * 48.0 / 1000.0).round();
+                    let normalized_decimal = (tick * 1000.0 / 48.0).round();
+                    if normalized_decimal != decimal {
+                        print!("{:?} != {:?}", normalized_decimal, decimal);
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+// Delays are lossily converted to stops for .sm output.
+// This is only relevant in conjunction with `is_sm`.
+#[inline(always)]
+fn has_delays(timing_segments: &TimingSegments) -> bool {
+    !timing_segments.delays.is_empty()
+}
+
+// Warps are converted to stops for .sm output,
+// lossily if any coincide with a stop/delay.
+// This is only relevant in conjunction with `is_sm`.
+#[inline(always)]
+fn has_warps(timing_segments: &TimingSegments) -> bool {
+    !timing_segments.warps.is_empty()
+}
+
+// Used to skip parity checks for specific fields in specific circumstances.
+// Most of these are related to .sm warp hacks or floating-point edge cases.
 struct Exemptions {
-    is_ssc: bool,
-    has_hash_breaking_bpms: bool,
-    has_warp_hacks: bool,
+    is_sm: bool,
+    has_noop_bpms: bool,
+    has_large_bpms: bool,
+    has_negative_bpms: bool,
+    has_misrounded_bpm_beats: bool,
+    has_delays: bool,
+    has_warps: bool,
+    has_noop_scrolls: bool,
 }
 
 impl Exemptions {
     fn for_simfile(expected: &SimfileSummary, is_ssc: bool) -> Exemptions {
         Exemptions {
-            is_ssc,
-            has_hash_breaking_bpms: has_hash_breaking_bpms(&expected.normalized_bpms),
-            has_warp_hacks: has_warp_hacks(is_ssc, &expected.global_timing_segments),
+            is_sm: !is_ssc,
+            has_noop_bpms: has_noop_bpms(&expected.normalized_bpms),
+            has_negative_bpms: has_negative_bpms(&expected.normalized_bpms),
+            has_large_bpms: has_large_bpms(&expected.normalized_bpms),
+            has_misrounded_bpm_beats: has_misrounded_bpm_beats(&expected.normalized_bpms),
+            has_delays: has_delays(&expected.global_timing_segments),
+            has_warps: has_warps(&expected.global_timing_segments),
+            has_noop_scrolls: has_noop_scrolls(&expected.normalized_scrolls),
         }
+    }
+
+    fn with_chart(&self, _expected: &ChartSummary) -> Exemptions {
+        Exemptions { ..*self }
+    }
+
+    fn skip_ssc_fields(&self) -> bool {
+        self.is_sm
+    }
+
+    fn skip_normalized_bpms(&self) -> bool {
+        self.has_noop_bpms || self.has_large_bpms || self.skip_possible_warp_hack_fields()
+    }
+
+    // The comparison function for normalized_bpms accounts for misrounded beats,
+    // but the hash cannot account for it, so additionally skip those cases here.
+    fn skip_hash(&self) -> bool {
+        self.skip_normalized_bpms() || self.has_misrounded_bpm_beats
+    }
+
+    fn skip_possible_warp_hack_fields(&self) -> bool {
+        self.has_negative_bpms || (self.is_sm && self.has_warps)
+    }
+
+    fn skip_delays_if_sm(&self) -> bool {
+        self.is_sm && self.has_delays
+    }
+
+    fn skip_normalized_scrolls(&self) -> bool {
+        self.has_noop_scrolls
     }
 }
 
@@ -225,7 +467,7 @@ fn compare_simfile_str_fields(
     compare_fields!(errors, expected, actual, eq, background_path);
     compare_fields!(errors, expected, actual, eq, banner_path);
 
-    if exemptions.is_ssc {
+    if !exemptions.skip_ssc_fields() {
         compare_fields!(errors, expected, actual, version_eq, ssc_version, is_default_version(0.83));
         compare_fields!(errors, expected, actual, eq, origin_str);
         compare_fields!(errors, expected, actual, eq, discimage_path);
@@ -249,25 +491,33 @@ fn compare_simfile_normalized_fields(
 ) -> Result<(), String> {
     let mut errors = String::new();
 
-    if !exemptions.has_hash_breaking_bpms && !exemptions.has_warp_hacks {
-        compare_fields!(errors, expected, actual, normalized_eq, normalized_bpms, is_default_str(NORM_DEFAULT_BPMS));
+    if !exemptions.skip_normalized_bpms() {
+        compare_fields_ml!(errors, expected, actual, normalized_beat_value_eq, normalized_bpms, is_default_str(NORM_DEFAULT_BPMS));
     }
-    if !exemptions.has_warp_hacks {
-        compare_fields!(errors, expected, actual, normalized_eq, normalized_stops);
-        compare_fields!(errors, expected, actual, normalized_eq, normalized_delays);
-        compare_fields!(errors, expected, actual, normalized_eq, normalized_warps);
+    if !exemptions.skip_possible_warp_hack_fields() && !exemptions.skip_delays_if_sm() {
+        compare_fields_ml!(errors, expected, actual, normalized_beat_value_eq, normalized_stops);
     }
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_speeds, is_default_str(NORM_DEFAULT_SPEEDS));
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_scrolls, is_default_str(NORM_DEFAULT_SCROLLS));
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_fakes);
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_time_signatures, is_default_str(DEFAULT_TIME_SIGNATURES));
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_labels, is_default_str(DEFAULT_LABELS));
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_tickcounts, is_default_str(DEFAULT_TICKCOUNTS));
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_combos, is_default_str(DEFAULT_COMBOS));
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_bgchanges);
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_fgchanges);
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_keysounds);
-    compare_fields!(errors, expected, actual, normalized_eq, normalized_attacks);
+    if !exemptions.skip_possible_warp_hack_fields() && !exemptions.skip_delays_if_sm() && !exemptions.skip_ssc_fields() {
+        compare_fields_ml!(errors, expected, actual, normalized_beat_value_eq, normalized_delays);
+    }
+    if !exemptions.skip_possible_warp_hack_fields() && !exemptions.skip_ssc_fields() {
+        compare_fields_ml!(errors, expected, actual, normalized_beat_beat_eq, normalized_warps);
+    }
+    if !exemptions.skip_normalized_scrolls() && !exemptions.skip_ssc_fields() {
+        compare_fields_ml!(errors, expected, actual, normalized_beat_value_eq, normalized_scrolls, is_default_str(NORM_DEFAULT_SCROLLS));
+    }
+    if !exemptions.skip_ssc_fields() {
+        compare_fields_ml!(errors, expected, actual, normalized_beat_str_eq, normalized_speeds, is_default_str(NORM_DEFAULT_SPEEDS));
+        compare_fields_ml!(errors, expected, actual, normalized_beat_beat_eq, normalized_fakes);
+        compare_fields_ml!(errors, expected, actual, eq, normalized_time_signatures, is_default_str(NORM_DEFAULT_TIME_SIGNATURES));
+        compare_fields_ml!(errors, expected, actual, eq, normalized_labels, is_default_str(NORM_DEFAULT_LABELS));
+        compare_fields_ml!(errors, expected, actual, eq, normalized_tickcounts, is_default_str(NORM_DEFAULT_TICKCOUNTS));
+        compare_fields_ml!(errors, expected, actual, eq, normalized_combos, is_default_str(NORM_DEFAULT_COMBOS));
+    }
+    compare_fields_ml!(errors, expected, actual, eq, normalized_bgchanges);
+    compare_fields_ml!(errors, expected, actual, eq, normalized_fgchanges);
+    compare_fields_ml!(errors, expected, actual, eq, normalized_keysounds);
+    compare_fields_ml!(errors, expected, actual, eq, normalized_attacks);
 
     if errors.is_empty() {
         Ok(())
@@ -286,15 +536,17 @@ fn compare_simfile_timing_fields(
     let expected_timing = &expected.global_timing_segments;
     let actual_timing = &actual.global_timing_segments;
 
-    if !exemptions.has_warp_hacks {
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, bpms, is_default_pairs(TIMING_DEFAULT_BPMS));
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, stops);
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, delays);
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, warps);
+    if !exemptions.skip_possible_warp_hack_fields() && !exemptions.skip_delays_if_sm() {
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, stops);
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, delays);
     }
-    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, scrolls, is_default_pairs(TIMING_DEFAULT_SCROLLS));
-    compare_fields!(errors, expected_timing, actual_timing, timing_speeds_eq, speeds, is_default_speeds(TIMING_DEFAULT_SPEEDS));
-    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, fakes);
+    if !exemptions.skip_possible_warp_hack_fields() {
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, bpms, is_default_pairs(TIMING_DEFAULT_BPMS));
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, warps);
+    }
+    compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, scrolls, is_default_pairs(TIMING_DEFAULT_SCROLLS));
+    compare_fields_ml!(errors, expected_timing, actual_timing, timing_speeds_eq, speeds, is_default_speeds(TIMING_DEFAULT_SPEEDS));
+    compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, fakes);
 
     if errors.is_empty() {
         Ok(())
@@ -338,24 +590,26 @@ fn compare_chart_hashes_and_timing(
     let expected_timing = &expected.timing_segments;
     let actual_timing = &actual.timing_segments;
 
-    if !exemptions.has_hash_breaking_bpms && !exemptions.has_warp_hacks {
+    if !exemptions.skip_hash() {
         compare_fields!(errors, expected, actual, eq, short_hash);
     }
     compare_fields!(errors, expected, actual, eq, bpm_neutral_hash);
     compare_fields!(errors, expected, actual, eq, chart_has_own_timing);
-    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_time_signatures, is_default_bytes_opt(DEFAULT_TIME_SIGNATURES));
-    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_labels, is_default_bytes_opt(DEFAULT_LABELS));
-    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_tickcounts, is_default_bytes_opt(DEFAULT_TICKCOUNTS));
-    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_combos, is_default_bytes_opt(DEFAULT_COMBOS));
-    if !exemptions.has_warp_hacks {
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, bpms, is_default_pairs(&[(0.0f32, 60.0f32)]));
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, stops);
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, delays);
-        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, warps);
+    compare_fields_ml!(errors, expected, actual, normalized_opt_eq, chart_time_signatures, is_default_bytes_opt(DEFAULT_TIME_SIGNATURES));
+    compare_fields_ml!(errors, expected, actual, normalized_opt_eq, chart_labels, is_default_bytes_opt(DEFAULT_LABELS));
+    compare_fields_ml!(errors, expected, actual, normalized_opt_eq, chart_tickcounts, is_default_bytes_opt(DEFAULT_TICKCOUNTS));
+    compare_fields_ml!(errors, expected, actual, normalized_opt_eq, chart_combos, is_default_bytes_opt(DEFAULT_COMBOS));
+    if !exemptions.skip_possible_warp_hack_fields() && !exemptions.skip_delays_if_sm() {
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, stops);
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, delays);
     }
-    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, scrolls, is_default_pairs(&[(0.0f32, 1.0f32)]));
-    compare_fields!(errors, expected_timing, actual_timing, timing_speeds_eq, speeds, is_default_speeds(&[(0.0f32, 1.0f32, 0.0f32, SpeedUnit::Beats)]));
-    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, fakes);
+    if !exemptions.skip_possible_warp_hack_fields() {
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, bpms, is_default_pairs(&[(0.0f32, 60.0f32)]));
+        compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, warps);
+    }
+    compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, scrolls, is_default_pairs(&[(0.0f32, 1.0f32)]));
+    compare_fields_ml!(errors, expected_timing, actual_timing, timing_speeds_eq, speeds, is_default_speeds(&[(0.0f32, 1.0f32, 0.0f32, SpeedUnit::Beats)]));
+    compare_fields_ml!(errors, expected_timing, actual_timing, timing_pairs_eq, fakes);
 
     if errors.is_empty() {
         Ok(())
@@ -394,11 +648,16 @@ fn compare_charts(
                 );
             }
             (Some(expected_chart), Some(actual_chart)) => {
-                match compare_chart_str_fields(expected_chart, actual_chart, exemptions) {
+                let chart_exemptions = exemptions.with_chart(expected_chart);
+                match compare_chart_str_fields(expected_chart, actual_chart, &chart_exemptions) {
                     Err(errs) => errors += &errs,
                     _ => {}
                 }
-                match compare_chart_hashes_and_timing(expected_chart, actual_chart, exemptions) {
+                match compare_chart_hashes_and_timing(
+                    expected_chart,
+                    actual_chart,
+                    &chart_exemptions,
+                ) {
                     Err(errs) => errors += &errs,
                     _ => {}
                 }
@@ -442,6 +701,8 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
         let mut cursor = io::Cursor::new(&mut buffer);
         serialize_simfile(&base_summary, extension, &mut cursor).map_err(|e| e.to_string())?;
     };
+
+    //print!("{}", String::from_utf8(buffer.clone()).unwrap());
 
     // Re-run rssp analyze on the serialized simfile
     let reencoded_summary = run_rssp_analyze(&buffer, extension)?;
@@ -607,7 +868,8 @@ fn main() {
             Err(msg) => {
                 println!("test {name} ... FAILED");
                 failures.push(Failure {
-                    name: path.to_string_lossy().to_string(),
+                    name,
+                    path: path.to_string_lossy().to_string(),
                     message: msg.trim().to_string(),
                 });
                 num_failed += 1;
@@ -626,7 +888,7 @@ fn main() {
 
         for failure in &failures {
             println!();
-            println!("---- {} ----", failure.name);
+            println!("---- {} ----", failure.path);
             if !failure.message.is_empty() {
                 println!("{}", failure.message);
             }

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -749,6 +749,15 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
 
     compare_simfile_str_fields(path, extension, &base_summary, &reencoded_summary)?;
     compare_simfile_normalized_fields(path, &base_summary, &reencoded_summary)?;
+
+    // A few SSC files in the corpus are missing a #VERSION tag
+    // but have per-chart timing data, which is invalid.
+    // Don't bother validating these.
+    if ssc && !base_summary.ssc_version.is_finite() {
+        println!("SSC file is missing a version - skipping chart & timing tests");
+        return Ok(());
+    };
+
     compare_chart_timing_fields(path, &base_summary.charts, &reencoded_summary.charts)?;
     compare_chart_str_fields_and_hashes(path, &base_summary.charts, &reencoded_summary.charts)?;
     compare_timing(path, &base_summary, &reencoded_summary)?;

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -13,6 +13,8 @@ use rssp::serialize::*;
 use rssp::stats::RADAR_CATEGORY_COUNT;
 use rssp::{AnalysisOptions, ChartSummary, SimfileSummary, analyze};
 
+static EMPTY: String = String::new();
+
 pub const NORM_DEFAULT_BPMS: &[u8] = b"0.000=60.000";
 pub const NORM_DEFAULT_SPEEDS: &[u8] = b"0.000=1.000=0.000=0";
 pub const NORM_DEFAULT_SCROLLS: &[u8] = b"0.000=1.000";
@@ -170,8 +172,8 @@ macro_rules! build_comparison_entry_opt {
     ($field: ident, $expected: expr, $actual: expr) => {
         (
             stringify!($field),
-            &$expected.$field,
-            &$actual.$field,
+            &$expected.$field.as_ref().unwrap_or_else(|| &EMPTY),
+            &$actual.$field.as_ref().unwrap_or_else(|| &EMPTY),
             $expected.$field == $actual.$field,
             None,
         )
@@ -179,14 +181,27 @@ macro_rules! build_comparison_entry_opt {
     ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
         (
             stringify!($field),
-            &$expected.$field,
-            &$actual.$field,
+            &$expected.$field.as_ref().unwrap_or_else(|| &EMPTY),
+            &$actual.$field.as_ref().unwrap_or_else(|| &EMPTY),
             $expected.$field == $actual.$field
                 || ($expected.$field.as_ref().is_none_or(|f| f.is_empty())
                     && $actual
                         .$field
                         .as_ref()
                         .is_some_and(|f| f.as_bytes() == $default)),
+            Some($default),
+        )
+    };
+}
+
+macro_rules! version_comparison_entry {
+    ($expected_version_str: expr, $actual_version_str: expr, $default: expr) => {
+        (
+            "VERSION",
+            $expected_version_str,
+            $actual_version_str,
+            $expected_version_str == $actual_version_str
+                || ($expected_version_str.is_empty() && $actual_version_str.as_bytes() == $default),
             Some($default),
         )
     };
@@ -235,8 +250,16 @@ fn compare_simfile_str_fields(
     actual: &SimfileSummary,
 ) -> Result<(), String> {
     let is_ssc = extension_is_ssc(extension).map_err(|e| e.to_string())?;
-    let expected_ssc_version_display = format!("{:.2}", expected.ssc_version);
-    let actual_ssc_version_display = format!("{:.2}", actual.ssc_version);
+    let expected_ssc_version = if expected.ssc_version.is_finite() {
+        format!("{:.2}", expected.ssc_version)
+    } else {
+        String::new()
+    };
+    let actual_ssc_version = if actual.ssc_version.is_finite() {
+        format!("{:.2}", actual.ssc_version)
+    } else {
+        String::new()
+    };
 
     let mut comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
         build_comparison_entry!(title_str, expected, actual, DEFAULT_TITLE),
@@ -256,18 +279,12 @@ fn compare_simfile_str_fields(
     ];
     if is_ssc {
         comparison_table.extend_from_slice(&[
+            version_comparison_entry!(&expected_ssc_version, &actual_ssc_version, DEFAULT_VERSION),
             build_comparison_entry!(origin_str, expected, actual),
             build_comparison_entry!(discimage_path, expected, actual),
             build_comparison_entry!(cdimage_path, expected, actual),
             build_comparison_entry!(previewvid_path, expected, actual),
             build_comparison_entry!(jacket_path, expected, actual),
-            (
-                "ssc_version",
-                &expected_ssc_version_display,
-                &actual_ssc_version_display,
-                expected.ssc_version == actual.ssc_version,
-                Some(DEFAULT_VERSION),
-            ),
         ]);
     }
 
@@ -277,32 +294,24 @@ fn compare_simfile_str_fields(
         return Ok(());
     }
 
-    // Build error string
-    let mut buffer = vec![];
-    {
-        let mut cursor = io::Cursor::new(&mut buffer);
-        for (field_name, expected, actual, cmp, _) in comparison_table {
-            writeln!(
-                &mut cursor,
-                "  {}: baseline: {:?} -> reencoded: {:?} {}",
-                field_name,
-                expected,
-                actual,
-                match cmp {
-                    true => "....ok",
-                    false => "....MISMATCH",
-                }
-            )
-            .map_err(|e| e.to_string())?;
-        }
-    } // Drop cursor
-
-    let err_output = String::from_utf8(buffer).unwrap();
+    let mut error_details = String::new();
+    for (field_name, expected, actual, cmp, _) in comparison_table {
+        error_details += &format!(
+            "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
+            field_name,
+            expected,
+            actual,
+            match cmp {
+                true => "....ok",
+                false => "....MISMATCH",
+            }
+        );
+    }
 
     Err(format!(
         "\n\nMISMATCH DETECTED\nFile: {}\n{}",
         path.display(),
-        err_output,
+        error_details,
     ))
 }
 
@@ -355,31 +364,24 @@ fn compare_simfile_normalized_fields(
     }
 
     // Build error string
-    let mut buffer = vec![];
-    {
-        let mut cursor = io::Cursor::new(&mut buffer);
-        for (field_name, expected, actual, cmp, _) in comparison_table {
-            writeln!(
-                &mut cursor,
-                "  {}: baseline: {:?} -> reencoded: {:?} {}",
-                field_name,
-                expected,
-                actual,
-                match cmp {
-                    true => "....ok",
-                    false => "....MISMATCH",
-                }
-            )
-            .map_err(|e| e.to_string())?;
-        }
-    } // Drop cursor
-
-    let err_output = String::from_utf8(buffer).unwrap();
+    let mut error_details = String::new();
+    for (field_name, expected, actual, cmp, _) in comparison_table {
+        error_details += &format!(
+            "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
+            field_name,
+            expected,
+            actual,
+            match cmp {
+                true => "....ok",
+                false => "....MISMATCH",
+            }
+        );
+    }
 
     Err(format!(
         "\n\nMISMATCH DETECTED\nFile: {}\n{}",
         path.display(),
-        err_output,
+        error_details,
     ))
 }
 
@@ -456,27 +458,21 @@ fn compare_chart_str_fields_and_hashes(
                 }
 
                 // Build error string
-                let mut buffer = vec![];
-                {
-                    let mut cursor = io::Cursor::new(&mut buffer);
-                    for (field_name, expected, actual, cmp, _) in comparison_table {
-                        writeln!(
-                            &mut cursor,
-                            "  {}: baseline: {:?} -> reencoded: {:?} {}",
-                            field_name,
-                            expected,
-                            actual,
-                            match cmp {
-                                true => "....ok",
-                                false => "....MISMATCH",
-                            }
-                        )
-                        .map_err(|e| e.to_string())?;
-                    }
-                } // Drop cursor
+                let mut error_details = String::new();
+                for (field_name, expected, actual, cmp, _) in comparison_table {
+                    error_details += &format!(
+                        "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
+                        field_name,
+                        expected,
+                        actual,
+                        match cmp {
+                            true => "....ok",
+                            false => "....MISMATCH",
+                        }
+                    );
+                }
 
-                let err_output = String::from_utf8(buffer).unwrap();
-                errors.push(err_output);
+                errors.push(error_details);
             }
         }
     }
@@ -485,7 +481,7 @@ fn compare_chart_str_fields_and_hashes(
         return Ok(());
     }
 
-    let mut error_details = String::from("Step artist mismatches:\n");
+    let mut error_details = String::from("Chart timing field mismatches:\n");
     for line in errors {
         error_details.push_str(&line);
         error_details.push('\n');
@@ -526,18 +522,17 @@ fn compare_chart_timing_fields(
             }
             (Some(expected_chart), Some(actual_chart)) => {
                 // Massage this boolean into a string to keep the comparison table simple
-                let expected_chart_has_own_timing =
-                    Some(expected_chart.chart_has_own_timing.to_string());
-                let actual_chart_has_own_timing =
-                    Some(actual_chart.chart_has_own_timing.to_string());
+                let expected_chart_has_own_timing = expected_chart.chart_has_own_timing.to_string();
+                let actual_chart_has_own_timing = actual_chart.chart_has_own_timing.to_string();
 
-                let comparison_table: Vec<(
-                    &str,
-                    &Option<String>,
-                    &Option<String>,
-                    bool,
-                    Option<&[u8]>,
-                )> = vec![
+                let comparison_table: Vec<(&str, &String, &String, bool, Option<&[u8]>)> = vec![
+                    // Compare these again here for important debugging context
+                    build_comparison_entry!(step_type_str, expected_chart, actual_chart),
+                    build_comparison_entry!(difficulty_str, expected_chart, actual_chart),
+                    build_comparison_entry!(rating_str, expected_chart, actual_chart),
+                    // Compare these again here to log timing data when hash breaks
+                    build_comparison_entry!(short_hash, expected_chart, actual_chart),
+                    build_comparison_entry!(bpm_neutral_hash, expected_chart, actual_chart),
                     (
                         "chart_has_own_timing",
                         &expected_chart_has_own_timing,
@@ -602,27 +597,21 @@ fn compare_chart_timing_fields(
                 }
 
                 // Build error string
-                let mut buffer = vec![];
-                {
-                    let mut cursor = io::Cursor::new(&mut buffer);
-                    for (field_name, expected, actual, cmp, _) in comparison_table {
-                        writeln!(
-                            &mut cursor,
-                            "  {}: baseline: {:?} -> reencoded: {:?} {}",
-                            field_name,
-                            expected,
-                            actual,
-                            match cmp {
-                                true => "....ok",
-                                false => "....MISMATCH",
-                            }
-                        )
-                        .map_err(|e| e.to_string())?;
-                    }
-                } // Drop cursor
+                let mut error_details = String::new();
+                for (field_name, expected, actual, cmp, _) in comparison_table {
+                    error_details += &format!(
+                        "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
+                        field_name,
+                        expected,
+                        actual,
+                        match cmp {
+                            true => "....ok",
+                            false => "....MISMATCH",
+                        }
+                    );
+                }
 
-                let err_output = String::from_utf8(buffer).unwrap();
-                errors.push(err_output);
+                errors.push(error_details);
             }
         }
     }
@@ -686,10 +675,10 @@ fn compare_timing(
                 }
 
                 // Build error string
-                let mut error = String::new();
+                let mut error_details = String::new();
                 for (field_name, matches) in timing_comparison_table {
-                    error += &format!(
-                        "  {}: {}",
+                    error_details += &format!(
+                        "  {}: {}\n",
                         field_name,
                         match matches {
                             true => "....ok",
@@ -698,12 +687,12 @@ fn compare_timing(
                     );
                 }
 
-                error += &format!(
+                error_details += &format!(
                     "\nExpected: {:?}\nActual: {:?}\n",
                     expected_timing, actual_timing
                 );
 
-                errors.push(error);
+                errors.push(error_details);
             }
         }
     }
@@ -758,17 +747,10 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
 
     println!("File: {}", path.display());
 
-    // let result = String::from_utf8(buffer);
-    // match result {
-    //     Ok(buffer_str) => println!("{}", buffer_str),
-    //     Err(_) => println!("debug failed"),
-    // }
-    // println!("{:?}", base_summary);
-
     compare_simfile_str_fields(path, extension, &base_summary, &reencoded_summary)?;
     compare_simfile_normalized_fields(path, &base_summary, &reencoded_summary)?;
-    compare_chart_str_fields_and_hashes(path, &base_summary.charts, &reencoded_summary.charts)?;
     compare_chart_timing_fields(path, &base_summary.charts, &reencoded_summary.charts)?;
+    compare_chart_str_fields_and_hashes(path, &base_summary.charts, &reencoded_summary.charts)?;
     compare_timing(path, &base_summary, &reencoded_summary)?;
 
     Ok(())

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -364,7 +364,7 @@ fn compare_simfile_normalized_fields(
     }
 
     // Build error string
-    let mut error_details = String::new();
+    let mut error_details = String::from("Simfile normalized field mismatches:\n");
     for (field_name, expected, actual, cmp, _) in comparison_table {
         error_details += &format!(
             "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
@@ -597,7 +597,7 @@ fn compare_chart_timing_fields(
                 }
 
                 // Build error string
-                let mut error_details = String::new();
+                let mut error_details = String::from("Chart timing field mismatches:\n");
                 for (field_name, expected, actual, cmp, _) in comparison_table {
                     error_details += &format!(
                         "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
@@ -620,7 +620,7 @@ fn compare_chart_timing_fields(
         return Ok(());
     }
 
-    let mut error_details = String::from("Chart mismatches:\n");
+    let mut error_details = String::new();
     for line in errors {
         error_details.push_str(&line);
         error_details.push('\n');
@@ -675,7 +675,7 @@ fn compare_timing(
                 }
 
                 // Build error string
-                let mut error_details = String::new();
+                let mut error_details = String::from("Chart timing data mismatches:\n");
                 for (field_name, matches) in timing_comparison_table {
                     error_details += &format!(
                         "  {}: {}\n",
@@ -728,6 +728,7 @@ fn run_rssp_analyze(raw_bytes: &[u8], extension: &str) -> Result<SimfileSummary,
 }
 
 fn check_file(path: &Path, extension: &str) -> Result<(), String> {
+    let ssc = extension_is_ssc(extension).map_err(|e| e.to_string())?;
     let compressed_bytes = fs::read(path).map_err(|e| format!("Failed to read file: {e}"))?;
 
     let raw_bytes = zstd::decode_all(&compressed_bytes[..])

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -1,0 +1,721 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use libtest_mimic::Arguments;
+use rssp::stats::RADAR_CATEGORY_COUNT;
+use walkdir::WalkDir;
+
+use rssp::report::{TimingSnapshot, build_timing_snapshot};
+use rssp::{AnalysisOptions, ChartSummary, SimfileSummary, analyze};
+
+#[derive(Debug, Clone)]
+struct TestCase {
+    name: String,
+    path: PathBuf,
+    extension: String,
+}
+
+#[derive(Debug, Clone)]
+struct Failure {
+    name: String,
+    message: String,
+}
+
+const TIMING_EPS: f64 = 1e-3;
+
+fn timing_approx_eq(a: &f64, b: &f64) -> bool {
+    (a - b).abs() <= TIMING_EPS
+}
+
+macro_rules! timing_matches_entry {
+    ($field: ident, $comparator: expr, $expected: expr, $actual: expr) => {
+        (
+            String::from(stringify!($field)),
+            $comparator(&$expected.$field, &$actual.$field),
+        )
+    };
+}
+
+fn build_timing_comparison_table(
+    expected: &TimingSnapshot,
+    actual: &TimingSnapshot,
+) -> Vec<(String, bool)> {
+    vec![
+        timing_matches_entry!(beat0_offset_seconds, timing_approx_eq, expected, actual),
+        timing_matches_entry!(bpms, compare_pairs, expected, actual),
+        timing_matches_entry!(stops, compare_pairs, expected, actual),
+        timing_matches_entry!(delays, compare_pairs, expected, actual),
+        timing_matches_entry!(warps, compare_pairs, expected, actual),
+        timing_matches_entry!(scrolls, compare_pairs, expected, actual),
+        timing_matches_entry!(fakes, compare_pairs, expected, actual),
+        timing_matches_entry!(time_signatures, compare_time_signatures, expected, actual),
+        timing_matches_entry!(labels, compare_labels, expected, actual),
+        timing_matches_entry!(tickcounts, compare_tickcounts, expected, actual),
+        timing_matches_entry!(combos, compare_combos, expected, actual),
+        timing_matches_entry!(speeds, compare_speeds, expected, actual),
+    ]
+}
+
+fn compare_pairs(expected: &[(f64, f64)], actual: &[(f64, f64)]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && timing_approx_eq(&e.1, &a.1))
+}
+
+fn compare_time_signatures(expected: &[(f64, i32, i32)], actual: &[(f64, i32, i32)]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1 && e.2 == a.2)
+}
+
+fn compare_labels(expected: &[(f64, String)], actual: &[(f64, String)]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1)
+}
+
+fn compare_tickcounts(expected: &[(f64, i32)], actual: &[(f64, i32)]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1)
+}
+
+fn compare_combos(expected: &[(f64, i32, i32)], actual: &[(f64, i32, i32)]) -> bool {
+    expected.len() == actual.len()
+        && expected
+            .iter()
+            .zip(actual)
+            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1 && e.2 == a.2)
+}
+
+fn compare_speeds(expected: &[(f64, f64, f64, i32)], actual: &[(f64, f64, f64, i32)]) -> bool {
+    expected.len() == actual.len()
+        && expected.iter().zip(actual).all(|(e, a)| {
+            timing_approx_eq(&e.0, &a.0)
+                && timing_approx_eq(&e.1, &a.1)
+                && timing_approx_eq(&e.2, &a.2)
+                && e.3 == a.3
+        })
+}
+
+fn compare_radar_values(
+    expected_opt: Option<&[f32; RADAR_CATEGORY_COUNT]>,
+    actual_opt: Option<&[f32; RADAR_CATEGORY_COUNT]>,
+) -> bool {
+    match (expected_opt, actual_opt) {
+        (None, None) => true,
+        (Some(expected), Some(actual)) => {
+            for i in 0..RADAR_CATEGORY_COUNT {
+                if expected[i] - actual[i] < 0.1e-3 {
+                    return false;
+                }
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
+    match radar_values {
+        Some(radar_values) => radar_values
+            .iter()
+            .map(|&f| rssp_core::math::fmt_dec6_itg(f as f64))
+            .collect::<Vec<String>>()
+            .join(","),
+        None => String::from(""),
+    }
+}
+
+macro_rules! build_comparison_entry {
+    ($field: ident, $expected: expr, $actual: expr) => {
+        (
+            stringify!($field),
+            &$expected.$field,
+            &$actual.$field,
+            $expected.$field == $actual.$field,
+        )
+    };
+}
+
+fn compare_simfile_str_fields(
+    path: &Path,
+    expected: &SimfileSummary,
+    actual: &SimfileSummary,
+) -> Result<(), String> {
+    let expected_ssc_version_display = format!("{:.2}", expected.ssc_version);
+    let actual_ssc_version_display = format!("{:.2}", actual.ssc_version);
+
+    let comparison_table: Vec<(&str, &str, &str, bool)> = vec![
+        build_comparison_entry!(title_str, expected, actual),
+        build_comparison_entry!(subtitle_str, expected, actual),
+        build_comparison_entry!(artist_str, expected, actual),
+        build_comparison_entry!(titletranslit_str, expected, actual),
+        build_comparison_entry!(subtitletranslit_str, expected, actual),
+        build_comparison_entry!(artisttranslit_str, expected, actual),
+        build_comparison_entry!(display_bpm_str, expected, actual),
+        build_comparison_entry!(credit_str, expected, actual),
+        build_comparison_entry!(origin_str, expected, actual),
+        build_comparison_entry!(genre_str, expected, actual),
+        build_comparison_entry!(lyrics_path, expected, actual),
+        build_comparison_entry!(discimage_path, expected, actual),
+        build_comparison_entry!(cdimage_path, expected, actual),
+        build_comparison_entry!(previewvid_path, expected, actual),
+        build_comparison_entry!(music_path, expected, actual),
+        build_comparison_entry!(jacket_path, expected, actual),
+        build_comparison_entry!(cdtitle_path, expected, actual),
+        build_comparison_entry!(background_path, expected, actual),
+        build_comparison_entry!(banner_path, expected, actual),
+        build_comparison_entry!(normalized_bpms, expected, actual),
+        build_comparison_entry!(normalized_stops, expected, actual),
+        build_comparison_entry!(normalized_delays, expected, actual),
+        build_comparison_entry!(normalized_speeds, expected, actual),
+        build_comparison_entry!(normalized_scrolls, expected, actual),
+        build_comparison_entry!(normalized_fakes, expected, actual),
+        build_comparison_entry!(normalized_time_signatures, expected, actual),
+        build_comparison_entry!(normalized_labels, expected, actual),
+        build_comparison_entry!(normalized_tickcounts, expected, actual),
+        build_comparison_entry!(normalized_combos, expected, actual),
+        build_comparison_entry!(normalized_bgchanges, expected, actual),
+        build_comparison_entry!(normalized_fgchanges, expected, actual),
+        build_comparison_entry!(normalized_keysounds, expected, actual),
+        build_comparison_entry!(normalized_attacks, expected, actual),
+        (
+            "ssc_version",
+            &expected_ssc_version_display,
+            &actual_ssc_version_display,
+            expected.ssc_version == actual.ssc_version,
+        ),
+    ];
+
+    let all_ok = comparison_table.iter().all(|entry| entry.3);
+
+    if all_ok {
+        return Ok(());
+    }
+
+    // Build error string
+    let mut buffer = vec![];
+    {
+        let mut cursor = io::Cursor::new(&mut buffer);
+        for (field_name, expected, actual, cmp) in comparison_table {
+            writeln!(
+                &mut cursor,
+                "  {}: baseline: {} -> reencoded: {} {}",
+                field_name,
+                expected,
+                actual,
+                match cmp {
+                    true => "....ok",
+                    false => "....MISMATCH",
+                }
+            )
+            .map_err(|e| e.to_string())?;
+        }
+    } // Drop cursor
+
+    let err_output = String::from_utf8(buffer).unwrap();
+
+    Err(format!(
+        "\n\nMISMATCH DETECTED\nFile: {}\n{}",
+        path.display(),
+        err_output,
+    ))
+}
+
+fn compare_chart_str_fields_and_hashes(
+    path: &Path,
+    expected_charts: &[ChartSummary],
+    actual_charts: &[ChartSummary],
+) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    let count = expected_charts.len().max(actual_charts.len());
+    for idx in 0..count {
+        let expected_chart_opt = expected_charts.get(idx);
+        let actual_chart_opt = actual_charts.get(idx);
+
+        match (expected_chart_opt, actual_chart_opt) {
+            (None, None) => panic!(), // Unreachable
+            (None, Some(actual_chart)) => {
+                errors.push(format!(
+                    "Unexpected {} {} chart at index {}",
+                    actual_chart.step_type_str, actual_chart.difficulty_str, idx
+                ));
+            }
+            (Some(expected_chart), None) => {
+                errors.push(format!(
+                    "Expected {} {} chart at index {}",
+                    expected_chart.step_type_str, expected_chart.difficulty_str, idx
+                ));
+            }
+            (Some(expected_chart), Some(actual_chart)) => {
+                let expected_radar_values = format_radar_values(expected_chart.cached_radar_values);
+                let actual_radar_values = format_radar_values(actual_chart.cached_radar_values);
+                let comparison_table: Vec<(&str, &str, &str, bool)> = vec![
+                    build_comparison_entry!(step_type_str, expected_chart, actual_chart),
+                    build_comparison_entry!(step_artist_str, expected_chart, actual_chart),
+                    build_comparison_entry!(description_str, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_name_str, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_style_str, expected_chart, actual_chart),
+                    build_comparison_entry!(difficulty_str, expected_chart, actual_chart),
+                    build_comparison_entry!(rating_str, expected_chart, actual_chart),
+                    build_comparison_entry!(short_hash, expected_chart, actual_chart),
+                    build_comparison_entry!(bpm_neutral_hash, expected_chart, actual_chart),
+                    (
+                        "cached_radar_values",
+                        &expected_radar_values,
+                        &actual_radar_values,
+                        compare_radar_values(
+                            expected_chart.cached_radar_values.as_ref(),
+                            actual_chart.cached_radar_values.as_ref(),
+                        ),
+                    ),
+                ];
+
+                let all_ok = comparison_table.iter().all(|entry| entry.3);
+
+                if all_ok {
+                    continue;
+                }
+
+                // Build error string
+                let mut buffer = vec![];
+                {
+                    let mut cursor = io::Cursor::new(&mut buffer);
+                    for (field_name, expected, actual, cmp) in comparison_table {
+                        writeln!(
+                            &mut cursor,
+                            "  {}: baseline: {} -> reencoded: {} {}",
+                            field_name,
+                            expected,
+                            actual,
+                            match cmp {
+                                true => "....ok",
+                                false => "....MISMATCH",
+                            }
+                        )
+                        .map_err(|e| e.to_string())?;
+                    }
+                } // Drop cursor
+
+                let err_output = String::from_utf8(buffer).unwrap();
+                errors.push(err_output);
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let mut error_details = String::from("Step artist mismatches:\n");
+    for line in errors {
+        error_details.push_str(&line);
+        error_details.push('\n');
+    }
+
+    Err(format!(
+        "\n\nMISMATCH DETECTED\nFile: {}\n{}\n",
+        path.display(),
+        error_details
+    ))
+}
+
+fn compare_chart_timing_fields(
+    path: &Path,
+    expected_charts: &[ChartSummary],
+    actual_charts: &[ChartSummary],
+) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    let count = expected_charts.len().max(actual_charts.len());
+    for idx in 0..count {
+        let expected_chart_opt = expected_charts.get(idx);
+        let actual_chart_opt = actual_charts.get(idx);
+
+        match (expected_chart_opt, actual_chart_opt) {
+            (None, None) => panic!(), // Unreachable
+            (None, Some(actual_chart)) => {
+                errors.push(format!(
+                    "Unexpected {} {} chart at index {}",
+                    actual_chart.step_type_str, actual_chart.difficulty_str, idx
+                ));
+            }
+            (Some(expected_chart), None) => {
+                errors.push(format!(
+                    "Expected {} {} chart at index {}",
+                    expected_chart.step_type_str, expected_chart.difficulty_str, idx
+                ));
+            }
+            (Some(expected_chart), Some(actual_chart)) => {
+                let some_true = Some(String::from("true"));
+                let some_false = Some(String::from("false"));
+
+                let comparison_table: Vec<(&str, &Option<String>, &Option<String>, bool)> = vec![
+                    (
+                        "chart_has_own_timing",
+                        if expected_chart.chart_has_own_timing {
+                            &some_true
+                        } else {
+                            &some_false
+                        },
+                        if actual_chart.chart_has_own_timing {
+                            &some_true
+                        } else {
+                            &some_false
+                        },
+                        expected_chart.chart_has_own_timing == actual_chart.chart_has_own_timing,
+                    ),
+                    build_comparison_entry!(chart_attacks, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_stops, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_speeds, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_scrolls, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_bpms, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_delays, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_warps, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_fakes, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_display_bpm, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_time_signatures, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_labels, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_tickcounts, expected_chart, actual_chart),
+                    build_comparison_entry!(chart_combos, expected_chart, actual_chart),
+                ];
+
+                let all_ok = comparison_table.iter().all(|entry| entry.3);
+
+                if all_ok {
+                    continue;
+                }
+
+                // Build error string
+                let mut buffer = vec![];
+                {
+                    let mut cursor = io::Cursor::new(&mut buffer);
+                    for (field_name, expected, actual, cmp) in comparison_table {
+                        writeln!(
+                            &mut cursor,
+                            "  {}: baseline: {:?} -> reencoded: {:?} {}",
+                            field_name,
+                            expected,
+                            actual,
+                            match cmp {
+                                true => "....ok",
+                                false => "....MISMATCH",
+                            }
+                        )
+                        .map_err(|e| e.to_string())?;
+                    }
+                } // Drop cursor
+
+                let err_output = String::from_utf8(buffer).unwrap();
+                errors.push(err_output);
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let mut error_details = String::from("Chart mismatches:\n");
+    for line in errors {
+        error_details.push_str(&line);
+        error_details.push('\n');
+    }
+
+    Err(format!(
+        "\n\nMISMATCH DETECTED\nFile: {}\n{}\n",
+        path.display(),
+        error_details
+    ))
+}
+
+fn compare_timing(
+    path: &Path,
+    expected_simfile: &SimfileSummary,
+    actual_simfile: &SimfileSummary,
+) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    let count = expected_simfile
+        .charts
+        .len()
+        .max(actual_simfile.charts.len());
+    for idx in 0..count {
+        let expected_chart_opt = expected_simfile.charts.get(idx);
+        let actual_chart_opt = actual_simfile.charts.get(idx);
+
+        match (expected_chart_opt, actual_chart_opt) {
+            (None, None) => panic!(), // Unreachable
+            (None, Some(actual_chart)) => {
+                errors.push(format!(
+                    "Unexpected {} {} chart at index {}",
+                    actual_chart.step_type_str, actual_chart.difficulty_str, idx
+                ));
+            }
+            (Some(expected_chart), None) => {
+                errors.push(format!(
+                    "Expected {} {} chart at index {}",
+                    expected_chart.step_type_str, expected_chart.difficulty_str, idx
+                ));
+            }
+            (Some(expected_chart), Some(actual_chart)) => {
+                let expected_timing = build_timing_snapshot(expected_chart, expected_simfile);
+                let actual_timing = build_timing_snapshot(actual_chart, actual_simfile);
+                let timing_comparison_table =
+                    build_timing_comparison_table(&expected_timing, &actual_timing);
+
+                let all_ok = timing_comparison_table.iter().all(|entry| entry.1);
+
+                if all_ok {
+                    continue;
+                }
+
+                // Build error string
+                let mut buffer = vec![];
+                {
+                    let mut cursor = io::Cursor::new(&mut buffer);
+                    for (field_name, matches) in timing_comparison_table {
+                        writeln!(
+                            &mut cursor,
+                            "  {}: {}",
+                            field_name,
+                            match matches {
+                                true => "....ok",
+                                false => "....MISMATCH",
+                            }
+                        )
+                        .map_err(|e| e.to_string())?;
+                    }
+                } // Drop cursor
+
+                let err_output = String::from_utf8(buffer).unwrap();
+                errors.push(err_output);
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let mut error_details = String::from("Timing mismatches:\n");
+    for line in errors {
+        error_details.push_str(&line);
+        error_details.push('\n');
+    }
+
+    Err(format!(
+        "\n\nMISMATCH DETECTED\nFile: {}\n{}\n",
+        path.display(),
+        error_details
+    ))
+}
+
+fn run_rssp_analyze(raw_bytes: &[u8], extension: &str) -> Result<SimfileSummary, String> {
+    let options = AnalysisOptions {
+        strip_tags: false,
+        mono_threshold: 6,
+        custom_patterns: Vec::new(),
+        compute_tech_counts: false,
+        compute_note_annotations: false,
+        compute_pattern_counts: false,
+        translate_markers: false,
+    };
+    analyze(raw_bytes, extension, &options)
+}
+
+fn check_file(path: &Path, extension: &str) -> Result<(), String> {
+    let compressed_bytes = fs::read(path).map_err(|e| format!("Failed to read file: {e}"))?;
+
+    let raw_bytes = zstd::decode_all(&compressed_bytes[..])
+        .map_err(|e| format!("Failed to decompress simfile: {e}"))?;
+
+    let base_summary = run_rssp_analyze(&raw_bytes, extension)?;
+
+    // Serialize to simfile bytes in memory
+    let mut buffer = vec![];
+    {
+        let mut cursor = io::Cursor::new(&mut buffer);
+        rssp::serialize::serialize_simfile(&base_summary, "ssc", &mut cursor)
+            .map_err(|e| e.to_string())?;
+    };
+
+    // Re-run rssp analyze on the serialized simfile
+    let reencoded_summary = run_rssp_analyze(&buffer, extension)?;
+
+    println!("File: {}", path.display());
+
+    compare_simfile_str_fields(path, &base_summary, &reencoded_summary)?;
+    compare_chart_str_fields_and_hashes(path, &base_summary.charts, &reencoded_summary.charts)?;
+    compare_chart_timing_fields(path, &base_summary.charts, &reencoded_summary.charts)?;
+    compare_timing(path, &base_summary, &reencoded_summary)?;
+
+    Ok(())
+}
+
+fn main() {
+    let interrupt = Arc::new(AtomicBool::new(false));
+    let handler_interrupt = interrupt.clone();
+    ctrlc::set_handler(move || {
+        handler_interrupt.store(true, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let args = Arguments::from_args();
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let packs_dir = manifest_dir.join("tests/data/packs");
+
+    if !packs_dir.exists() {
+        println!("No tests/packs directory found.");
+        return;
+    }
+
+    let mut tests = Vec::new();
+
+    for entry in WalkDir::new(&packs_dir)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "zst" {
+            continue;
+        }
+
+        let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        let inner_path = Path::new(stem);
+        let inner_extension = inner_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_lowercase)
+            .unwrap_or_default();
+
+        if inner_extension != "sm" && inner_extension != "ssc" {
+            continue;
+        }
+
+        let test_name = path
+            .strip_prefix(&packs_dir)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+
+        tests.push(TestCase {
+            name: test_name,
+            path: path.to_path_buf(),
+            extension: inner_extension,
+        });
+    }
+
+    tests.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut tests: Vec<_> = tests
+        .into_iter()
+        .filter(|t| match &args.filter {
+            None => true,
+            Some(filter) => {
+                if args.exact {
+                    &t.name == filter
+                } else {
+                    t.name.contains(filter)
+                }
+            }
+        })
+        .filter(|t| args.skip.iter().all(|skip| !t.name.contains(skip)))
+        .collect();
+
+    if args.ignored {
+        tests.clear();
+    }
+
+    if args.list {
+        for t in &tests {
+            println!("{}", t.name);
+        }
+        return;
+    }
+
+    println!("running {} tests", tests.len());
+
+    let mut num_passed = 0u64;
+    let mut num_failed = 0u64;
+    let mut failures: Vec<Failure> = Vec::new();
+
+    for test in tests {
+        if interrupt.load(Ordering::SeqCst) {
+            break;
+        }
+
+        let TestCase {
+            name,
+            path,
+            extension,
+        } = test;
+
+        let res = check_file(&path, &extension);
+        match res {
+            Ok(()) => {
+                println!("test {name} ... ok");
+                num_passed += 1;
+            }
+            Err(msg) => {
+                println!("test {name} ... FAILED");
+                failures.push(Failure {
+                    name,
+                    message: msg.trim().to_string(),
+                });
+                num_failed += 1;
+            }
+        }
+
+        let _ = io::stdout().flush();
+    }
+
+    println!();
+    if !failures.is_empty() {
+        println!("failures:");
+        for failure in &failures {
+            println!("    {}", failure.name);
+        }
+
+        for failure in &failures {
+            println!();
+            println!("---- {} ----", failure.name);
+            if !failure.message.is_empty() {
+                println!("{}", failure.message);
+            }
+            println!();
+            println!(
+                "rerun: cargo test --test serialize_parity -- --exact {:?}",
+                failure.name
+            );
+        }
+        println!();
+    }
+
+    if num_failed == 0 {
+        println!("test result: ok. {num_passed} passed; 0 failed");
+        return;
+    }
+
+    println!("test result: FAILED. {num_passed} passed; {num_failed} failed");
+    std::process::exit(101);
+}

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -3,12 +3,15 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::sleep;
+use std::time::Duration;
 
 use libtest_mimic::Arguments;
-use rssp::stats::RADAR_CATEGORY_COUNT;
 use walkdir::WalkDir;
 
 use rssp::report::{TimingSnapshot, build_timing_snapshot};
+use rssp::serialize::*;
+use rssp::stats::RADAR_CATEGORY_COUNT;
 use rssp::{AnalysisOptions, ChartSummary, SimfileSummary, analyze};
 
 #[derive(Debug, Clone)]
@@ -117,7 +120,7 @@ fn compare_radar_values(
         (None, None) => true,
         (Some(expected), Some(actual)) => {
             for i in 0..RADAR_CATEGORY_COUNT {
-                if expected[i] - actual[i] < 0.1e-3 {
+                if expected[i] - actual[i] > 1e-6 {
                     return false;
                 }
             }
@@ -145,6 +148,43 @@ macro_rules! build_comparison_entry {
             &$expected.$field,
             &$actual.$field,
             $expected.$field == $actual.$field,
+            None,
+        )
+    };
+    ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
+        (
+            stringify!($field),
+            &$expected.$field,
+            &$actual.$field,
+            $expected.$field == $actual.$field
+                || ($expected.$field.is_empty() && $actual.$field.as_bytes() == $default),
+            Some($default),
+        )
+    };
+}
+
+macro_rules! build_comparison_entry_opt {
+    ($field: ident, $expected: expr, $actual: expr) => {
+        (
+            stringify!($field),
+            &$expected.$field,
+            &$actual.$field,
+            $expected.$field == $actual.$field,
+            None,
+        )
+    };
+    ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
+        (
+            stringify!($field),
+            &$expected.$field,
+            &$actual.$field,
+            $expected.$field == $actual.$field
+                || ($expected.$field.as_ref().is_none_or(|f| f.is_empty())
+                    && $actual
+                        .$field
+                        .as_ref()
+                        .is_some_and(|f| f.as_bytes() == $default)),
+            Some($default),
         )
     };
 }
@@ -157,10 +197,10 @@ fn compare_simfile_str_fields(
     let expected_ssc_version_display = format!("{:.2}", expected.ssc_version);
     let actual_ssc_version_display = format!("{:.2}", actual.ssc_version);
 
-    let comparison_table: Vec<(&str, &str, &str, bool)> = vec![
-        build_comparison_entry!(title_str, expected, actual),
+    let comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
+        build_comparison_entry!(title_str, expected, actual, DEFAULT_TITLE),
         build_comparison_entry!(subtitle_str, expected, actual),
-        build_comparison_entry!(artist_str, expected, actual),
+        build_comparison_entry!(artist_str, expected, actual, DEFAULT_ARTIST),
         build_comparison_entry!(titletranslit_str, expected, actual),
         build_comparison_entry!(subtitletranslit_str, expected, actual),
         build_comparison_entry!(artisttranslit_str, expected, actual),
@@ -177,16 +217,21 @@ fn compare_simfile_str_fields(
         build_comparison_entry!(cdtitle_path, expected, actual),
         build_comparison_entry!(background_path, expected, actual),
         build_comparison_entry!(banner_path, expected, actual),
-        build_comparison_entry!(normalized_bpms, expected, actual),
+        build_comparison_entry!(normalized_bpms, expected, actual, DEFAULT_BPMS),
         build_comparison_entry!(normalized_stops, expected, actual),
         build_comparison_entry!(normalized_delays, expected, actual),
-        build_comparison_entry!(normalized_speeds, expected, actual),
-        build_comparison_entry!(normalized_scrolls, expected, actual),
+        build_comparison_entry!(normalized_speeds, expected, actual, DEFAULT_SPEEDS),
+        build_comparison_entry!(normalized_scrolls, expected, actual, DEFAULT_SCROLLS),
         build_comparison_entry!(normalized_fakes, expected, actual),
-        build_comparison_entry!(normalized_time_signatures, expected, actual),
-        build_comparison_entry!(normalized_labels, expected, actual),
-        build_comparison_entry!(normalized_tickcounts, expected, actual),
-        build_comparison_entry!(normalized_combos, expected, actual),
+        build_comparison_entry!(
+            normalized_time_signatures,
+            expected,
+            actual,
+            DEFAULT_TIME_SIGNATURES
+        ),
+        build_comparison_entry!(normalized_labels, expected, actual, DEFAULT_LABELS),
+        build_comparison_entry!(normalized_tickcounts, expected, actual, DEFAULT_TICKCOUNTS),
+        build_comparison_entry!(normalized_combos, expected, actual, DEFAULT_COMBOS),
         build_comparison_entry!(normalized_bgchanges, expected, actual),
         build_comparison_entry!(normalized_fgchanges, expected, actual),
         build_comparison_entry!(normalized_keysounds, expected, actual),
@@ -196,6 +241,7 @@ fn compare_simfile_str_fields(
             &expected_ssc_version_display,
             &actual_ssc_version_display,
             expected.ssc_version == actual.ssc_version,
+            Some(DEFAULT_VERSION),
         ),
     ];
 
@@ -209,7 +255,7 @@ fn compare_simfile_str_fields(
     let mut buffer = vec![];
     {
         let mut cursor = io::Cursor::new(&mut buffer);
-        for (field_name, expected, actual, cmp) in comparison_table {
+        for (field_name, expected, actual, cmp, _) in comparison_table {
             writeln!(
                 &mut cursor,
                 "  {}: baseline: {} -> reencoded: {} {}",
@@ -263,14 +309,29 @@ fn compare_chart_str_fields_and_hashes(
             (Some(expected_chart), Some(actual_chart)) => {
                 let expected_radar_values = format_radar_values(expected_chart.cached_radar_values);
                 let actual_radar_values = format_radar_values(actual_chart.cached_radar_values);
-                let comparison_table: Vec<(&str, &str, &str, bool)> = vec![
-                    build_comparison_entry!(step_type_str, expected_chart, actual_chart),
+                let comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
+                    build_comparison_entry!(
+                        step_type_str,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_STEPSTYPE
+                    ),
                     build_comparison_entry!(step_artist_str, expected_chart, actual_chart),
                     build_comparison_entry!(description_str, expected_chart, actual_chart),
                     build_comparison_entry!(chart_name_str, expected_chart, actual_chart),
                     build_comparison_entry!(chart_style_str, expected_chart, actual_chart),
-                    build_comparison_entry!(difficulty_str, expected_chart, actual_chart),
-                    build_comparison_entry!(rating_str, expected_chart, actual_chart),
+                    build_comparison_entry!(
+                        difficulty_str,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_DIFFICULTY
+                    ),
+                    build_comparison_entry!(
+                        rating_str,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_METER
+                    ),
                     build_comparison_entry!(short_hash, expected_chart, actual_chart),
                     build_comparison_entry!(bpm_neutral_hash, expected_chart, actual_chart),
                     (
@@ -281,6 +342,7 @@ fn compare_chart_str_fields_and_hashes(
                             expected_chart.cached_radar_values.as_ref(),
                             actual_chart.cached_radar_values.as_ref(),
                         ),
+                        None,
                     ),
                 ];
 
@@ -294,7 +356,7 @@ fn compare_chart_str_fields_and_hashes(
                 let mut buffer = vec![];
                 {
                     let mut cursor = io::Cursor::new(&mut buffer);
-                    for (field_name, expected, actual, cmp) in comparison_table {
+                    for (field_name, expected, actual, cmp, _) in comparison_table {
                         writeln!(
                             &mut cursor,
                             "  {}: baseline: {} -> reencoded: {} {}",
@@ -360,37 +422,74 @@ fn compare_chart_timing_fields(
                 ));
             }
             (Some(expected_chart), Some(actual_chart)) => {
-                let some_true = Some(String::from("true"));
-                let some_false = Some(String::from("false"));
+                // Massage this boolean into a string to keep the comparison table simple
+                let expected_chart_has_own_timing =
+                    Some(expected_chart.chart_has_own_timing.to_string());
+                let actual_chart_has_own_timing =
+                    Some(actual_chart.chart_has_own_timing.to_string());
 
-                let comparison_table: Vec<(&str, &Option<String>, &Option<String>, bool)> = vec![
+                let comparison_table: Vec<(
+                    &str,
+                    &Option<String>,
+                    &Option<String>,
+                    bool,
+                    Option<&[u8]>,
+                )> = vec![
                     (
                         "chart_has_own_timing",
-                        if expected_chart.chart_has_own_timing {
-                            &some_true
-                        } else {
-                            &some_false
-                        },
-                        if actual_chart.chart_has_own_timing {
-                            &some_true
-                        } else {
-                            &some_false
-                        },
+                        &expected_chart_has_own_timing,
+                        &actual_chart_has_own_timing,
                         expected_chart.chart_has_own_timing == actual_chart.chart_has_own_timing,
+                        None,
                     ),
-                    build_comparison_entry!(chart_attacks, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_stops, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_speeds, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_scrolls, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_bpms, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_delays, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_warps, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_fakes, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_display_bpm, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_time_signatures, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_labels, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_tickcounts, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_combos, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(chart_attacks, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(chart_stops, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(
+                        chart_speeds,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_SPEEDS
+                    ),
+                    build_comparison_entry_opt!(
+                        chart_scrolls,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_SCROLLS
+                    ),
+                    build_comparison_entry_opt!(
+                        chart_bpms,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_BPMS
+                    ),
+                    build_comparison_entry_opt!(chart_delays, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(chart_warps, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(chart_fakes, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(chart_display_bpm, expected_chart, actual_chart),
+                    build_comparison_entry_opt!(
+                        chart_time_signatures,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_TIME_SIGNATURES
+                    ),
+                    build_comparison_entry_opt!(
+                        chart_labels,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_LABELS
+                    ),
+                    build_comparison_entry_opt!(
+                        chart_tickcounts,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_TICKCOUNTS
+                    ),
+                    build_comparison_entry_opt!(
+                        chart_combos,
+                        expected_chart,
+                        actual_chart,
+                        DEFAULT_COMBOS
+                    ),
                 ];
 
                 let all_ok = comparison_table.iter().all(|entry| entry.3);
@@ -403,7 +502,7 @@ fn compare_chart_timing_fields(
                 let mut buffer = vec![];
                 {
                     let mut cursor = io::Cursor::new(&mut buffer);
-                    for (field_name, expected, actual, cmp) in comparison_table {
+                    for (field_name, expected, actual, cmp, _) in comparison_table {
                         writeln!(
                             &mut cursor,
                             "  {}: baseline: {:?} -> reencoded: {:?} {}",
@@ -549,9 +648,17 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
     let mut buffer = vec![];
     {
         let mut cursor = io::Cursor::new(&mut buffer);
-        rssp::serialize::serialize_simfile(&base_summary, "ssc", &mut cursor)
-            .map_err(|e| e.to_string())?;
+        serialize_simfile(&base_summary, extension, &mut cursor).map_err(|e| e.to_string())?;
     };
+
+    // for chart in &base_summary.charts {
+    //     if chart.bpm_neutral_hash == "a5830d9474451c26" {
+    //         unsafe {
+    //             eprintln!("{}", String::from_utf8_unchecked(buffer.clone()));
+    //             sleep(Duration::from_secs(1));
+    //         }
+    //     }
+    // }
 
     // Re-run rssp analyze on the serialized simfile
     let reencoded_summary = run_rssp_analyze(&buffer, extension)?;

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -5,19 +5,21 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use libtest_mimic::Arguments;
-use rssp::parse::extension_is_ssc;
 use walkdir::WalkDir;
 
-use rssp::report::{TimingSnapshot, build_timing_snapshot};
+use rssp::parse::extension_is_ssc;
 use rssp::serialize::*;
 use rssp::stats::RADAR_CATEGORY_COUNT;
+use rssp::timing::{SpeedUnit, TimingSegments};
 use rssp::{AnalysisOptions, ChartSummary, SimfileSummary, analyze};
-
-static EMPTY: String = String::new();
 
 pub const NORM_DEFAULT_BPMS: &[u8] = b"0.000=60.000";
 pub const NORM_DEFAULT_SPEEDS: &[u8] = b"0.000=1.000=0.000=0";
 pub const NORM_DEFAULT_SCROLLS: &[u8] = b"0.000=1.000";
+pub const TIMING_DEFAULT_BPMS: &[(f32, f32)] = &[(0.0f32, 60.0f32)];
+pub const TIMING_DEFAULT_SPEEDS: &[(f32, f32, f32, SpeedUnit)] =
+    &[(0.0f32, 1.0f32, 0.0f32, SpeedUnit::Beats)];
+pub const TIMING_DEFAULT_SCROLLS: &[(f32, f32)] = &[(0.0f32, 1.0f32)];
 
 #[derive(Debug, Clone)]
 struct TestCase {
@@ -32,94 +34,15 @@ struct Failure {
     message: String,
 }
 
-const TIMING_EPS: f64 = 1e-3;
+const TIMING_EPS: f32 = 1e-3;
 
-fn timing_approx_eq(a: &f64, b: &f64) -> bool {
+fn timing_approx_eq(a: &f32, b: &f32) -> bool {
     (a - b).abs() <= TIMING_EPS
 }
 
-macro_rules! timing_matches_entry {
-    ($field: ident, $comparator: expr, $expected: expr, $actual: expr) => {
-        (
-            String::from(stringify!($field)),
-            $comparator(&$expected.$field, &$actual.$field),
-        )
-    };
-}
-
-fn build_timing_comparison_table(
-    expected: &TimingSnapshot,
-    actual: &TimingSnapshot,
-) -> Vec<(String, bool)> {
-    vec![
-        timing_matches_entry!(beat0_offset_seconds, timing_approx_eq, expected, actual),
-        timing_matches_entry!(bpms, compare_pairs, expected, actual),
-        timing_matches_entry!(stops, compare_pairs, expected, actual),
-        timing_matches_entry!(delays, compare_pairs, expected, actual),
-        timing_matches_entry!(warps, compare_pairs, expected, actual),
-        timing_matches_entry!(scrolls, compare_pairs, expected, actual),
-        timing_matches_entry!(fakes, compare_pairs, expected, actual),
-        timing_matches_entry!(time_signatures, compare_time_signatures, expected, actual),
-        timing_matches_entry!(labels, compare_labels, expected, actual),
-        timing_matches_entry!(tickcounts, compare_tickcounts, expected, actual),
-        timing_matches_entry!(combos, compare_combos, expected, actual),
-        timing_matches_entry!(speeds, compare_speeds, expected, actual),
-    ]
-}
-
-fn compare_pairs(expected: &[(f64, f64)], actual: &[(f64, f64)]) -> bool {
-    expected.len() == actual.len()
-        && expected
-            .iter()
-            .zip(actual)
-            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && timing_approx_eq(&e.1, &a.1))
-}
-
-fn compare_time_signatures(expected: &[(f64, i32, i32)], actual: &[(f64, i32, i32)]) -> bool {
-    expected.len() == actual.len()
-        && expected
-            .iter()
-            .zip(actual)
-            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1 && e.2 == a.2)
-}
-
-fn compare_labels(expected: &[(f64, String)], actual: &[(f64, String)]) -> bool {
-    expected.len() == actual.len()
-        && expected
-            .iter()
-            .zip(actual)
-            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1)
-}
-
-fn compare_tickcounts(expected: &[(f64, i32)], actual: &[(f64, i32)]) -> bool {
-    expected.len() == actual.len()
-        && expected
-            .iter()
-            .zip(actual)
-            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1)
-}
-
-fn compare_combos(expected: &[(f64, i32, i32)], actual: &[(f64, i32, i32)]) -> bool {
-    expected.len() == actual.len()
-        && expected
-            .iter()
-            .zip(actual)
-            .all(|(e, a)| timing_approx_eq(&e.0, &a.0) && e.1 == a.1 && e.2 == a.2)
-}
-
-fn compare_speeds(expected: &[(f64, f64, f64, i32)], actual: &[(f64, f64, f64, i32)]) -> bool {
-    expected.len() == actual.len()
-        && expected.iter().zip(actual).all(|(e, a)| {
-            timing_approx_eq(&e.0, &a.0)
-                && timing_approx_eq(&e.1, &a.1)
-                && timing_approx_eq(&e.2, &a.2)
-                && e.3 == a.3
-        })
-}
-
-fn compare_radar_values(
-    expected_opt: Option<&[f32; RADAR_CATEGORY_COUNT]>,
-    actual_opt: Option<&[f32; RADAR_CATEGORY_COUNT]>,
+fn radar_values_eq(
+    expected_opt: &Option<[f32; RADAR_CATEGORY_COUNT]>,
+    actual_opt: &Option<[f32; RADAR_CATEGORY_COUNT]>,
 ) -> bool {
     match (expected_opt, actual_opt) {
         (None, None) => true,
@@ -135,81 +58,64 @@ fn compare_radar_values(
     }
 }
 
-fn format_radar_values(radar_values: Option<[f32; RADAR_CATEGORY_COUNT]>) -> String {
-    match radar_values {
-        Some(radar_values) => radar_values
-            .iter()
-            .map(|&f| rssp_core::math::fmt_dec6_itg(f as f64))
-            .collect::<Vec<String>>()
-            .join(","),
-        None => String::from(""),
-    }
-}
-
-macro_rules! build_comparison_entry {
-    ($field: ident, $expected: expr, $actual: expr) => {
-        (
-            stringify!($field),
-            &$expected.$field,
-            &$actual.$field,
-            $expected.$field == $actual.$field,
-            None,
-        )
+macro_rules! compare_fields {
+    ($errors: expr, $expected: expr, $actual: expr, $eq_fn: ident, $field: ident) => {
+        compare_fields!($errors, $expected, $actual, $eq_fn, $field, (|_, _| false))
     };
-    ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
-        (
-            stringify!($field),
-            &$expected.$field,
-            &$actual.$field,
-            $expected.$field == $actual.$field
-                || ($expected.$field.is_empty() && $actual.$field.as_bytes() == $default),
-            Some($default),
-        )
+    ($errors: expr, $expected: expr, $actual: expr, $eq_fn: ident, $field: ident, $is_default_fn: expr) => {
+        (if !$eq_fn(&$expected.$field, &$actual.$field)
+            && !$is_default_fn(&$expected.$field, &$actual.$field)
+        {
+            $errors += &format!(
+                "{}: baseline: {:?} -> reencoded: {:?} ....MISMATCH\n",
+                stringify!($field),
+                $expected.$field,
+                $actual.$field,
+            );
+        })
     };
 }
 
-macro_rules! build_comparison_entry_opt {
-    ($field: ident, $expected: expr, $actual: expr) => {
-        (
-            stringify!($field),
-            &$expected.$field.as_ref().unwrap_or_else(|| &EMPTY),
-            &$actual.$field.as_ref().unwrap_or_else(|| &EMPTY),
-            $expected.$field == $actual.$field,
-            None,
-        )
-    };
-    ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
-        (
-            stringify!($field),
-            &$expected.$field.as_ref().unwrap_or_else(|| &EMPTY),
-            &$actual.$field.as_ref().unwrap_or_else(|| &EMPTY),
-            $expected.$field == $actual.$field
-                || ($expected.$field.as_ref().is_none_or(|f| f.is_empty())
-                    && $actual
-                        .$field
-                        .as_ref()
-                        .is_some_and(|f| f.as_bytes() == $default)),
-            Some($default),
-        )
-    };
+fn eq<T: Eq>(expected: &T, actual: &T) -> bool {
+    expected == actual
 }
 
-macro_rules! version_comparison_entry {
-    ($expected_version_str: expr, $actual_version_str: expr, $default: expr) => {
-        (
-            "VERSION",
-            $expected_version_str,
-            $actual_version_str,
-            $expected_version_str == $actual_version_str
-                || ($expected_version_str.is_empty() && $actual_version_str.as_bytes() == $default),
-            Some($default),
-        )
-    };
+fn timing_pairs_eq(expected: &Vec<(f32, f32)>, actual: &Vec<(f32, f32)>) -> bool {
+    expected
+        .iter()
+        .zip(actual.iter())
+        .all(|(a, b)| timing_approx_eq(&a.0, &b.0) && timing_approx_eq(&a.1, &b.1))
 }
 
-fn normalized_eq(a: &str, b: &str) -> bool {
-    let mut a_lines = a.lines();
-    let mut b_lines = b.lines();
+fn timing_speeds_eq(
+    expected: &Vec<(f32, f32, f32, SpeedUnit)>,
+    actual: &Vec<(f32, f32, f32, SpeedUnit)>,
+) -> bool {
+    expected.iter().zip(actual.iter()).all(|(a, b)| {
+        timing_approx_eq(&a.0, &b.0)
+            && timing_approx_eq(&a.1, &b.1)
+            && timing_approx_eq(&a.2, &b.2)
+            && a.3 == b.3
+    })
+}
+
+fn version_eq(expected: &f32, actual: &f32) -> bool {
+    let expected_str = if expected.is_finite() {
+        format!("{:.2}", expected)
+    } else {
+        String::new()
+    };
+    let actual_str = if actual.is_finite() {
+        format!("{:.2}", actual)
+    } else {
+        String::new()
+    };
+    expected_str == actual_str
+}
+
+fn normalized_eq(expected: &str, actual: &str) -> bool {
+    let mut a_lines = expected.lines();
+    let mut b_lines = actual.lines();
     for (line_a, line_b) in a_lines.by_ref().zip(b_lines.by_ref()) {
         if line_a != line_b {
             return false;
@@ -221,424 +127,249 @@ fn normalized_eq(a: &str, b: &str) -> bool {
     true
 }
 
-macro_rules! build_normalized_comparison_entry {
-    ($field: ident, $expected: expr, $actual: expr) => {
-        (
-            stringify!($field),
-            &$expected.$field,
-            &$actual.$field,
-            normalized_eq(&$expected.$field, &$actual.$field),
-            None,
-        )
-    };
-    ($field: ident, $expected: expr, $actual: expr, $default: expr) => {
-        (
-            stringify!($field),
-            &$expected.$field,
-            &$actual.$field,
-            normalized_eq(&$expected.$field, &$actual.$field)
-                || ($expected.$field.is_empty() && $actual.$field.as_bytes() == $default),
-            Some($default),
-        )
-    };
+fn normalized_opt_eq(expected: &Option<String>, actual: &Option<String>) -> bool {
+    match (expected, actual) {
+        (Some(a), Some(b)) => normalized_eq(a, b),
+        (None, None) => true,
+        _ => false,
+    }
 }
 
+fn is_default_str(default: &[u8]) -> impl Fn(&str, &str) -> bool {
+    move |a, b| a.is_empty() && b.as_bytes() == default
+}
+
+fn is_default_version(default: f32) -> impl Fn(&f32, &f32) -> bool {
+    move |a, b| !a.is_finite() && *b == default
+}
+
+fn is_default_bytes_opt(default: &[u8]) -> impl Fn(&Option<String>, &Option<String>) -> bool {
+    move |e, a| {
+        e.as_ref().is_none_or(|e| e.is_empty())
+            && a.as_ref().is_some_and(|a| a.as_bytes() == default)
+    }
+}
+
+fn is_default_pairs(default: &[(f32, f32)]) -> impl Fn(&Vec<(f32, f32)>, &Vec<(f32, f32)>) -> bool {
+    move |e, a| e.is_empty() && a == &default
+}
+
+fn is_default_speeds(
+    default: &[(f32, f32, f32, SpeedUnit)],
+) -> impl Fn(&Vec<(f32, f32, f32, SpeedUnit)>, &Vec<(f32, f32, f32, SpeedUnit)>) -> bool {
+    move |e, a| e.is_empty() && a == &default
+}
+
+// StepMania and DeadSync both strip certain BPMs during parsing,
+// which will inevitably change the normalized BPMs and chart hashes after serializing.
+// Use this function to determine when to ignore changes to those fields.
+fn has_hash_breaking_bpms(normalized_bpms: &str) -> bool {
+    let mut previous_beat: &str = "";
+    let mut previous_value: &str = "";
+    for pair in normalized_bpms.split(",") {
+        if let Some((beat, value)) = pair.split_once('=') {
+            if value == "0.000" {
+                return true;
+            } else if beat == previous_beat || value == previous_value {
+                return true;
+            }
+            previous_beat = beat;
+            previous_value = value;
+        }
+    }
+    false
+}
+
+#[inline(always)]
+fn has_warp_hacks(is_ssc: bool, timing_segments: &TimingSegments) -> bool {
+    !is_ssc && !timing_segments.warps.is_empty()
+}
+
+struct Exemptions {
+    is_ssc: bool,
+    has_hash_breaking_bpms: bool,
+    has_warp_hacks: bool,
+}
+
+impl Exemptions {
+    fn for_simfile(expected: &SimfileSummary, is_ssc: bool) -> Exemptions {
+        Exemptions {
+            is_ssc,
+            has_hash_breaking_bpms: has_hash_breaking_bpms(&expected.normalized_bpms),
+            has_warp_hacks: has_warp_hacks(is_ssc, &expected.global_timing_segments),
+        }
+    }
+}
+
+#[rustfmt::skip]
 fn compare_simfile_str_fields(
-    path: &Path,
-    extension: &str,
     expected: &SimfileSummary,
     actual: &SimfileSummary,
+    exemptions: &Exemptions,
 ) -> Result<(), String> {
-    let is_ssc = extension_is_ssc(extension).map_err(|e| e.to_string())?;
-    let expected_ssc_version = if expected.ssc_version.is_finite() {
-        format!("{:.2}", expected.ssc_version)
+
+    let mut errors = String::new();
+
+    compare_fields!(errors, expected, actual, eq, title_str, is_default_str(DEFAULT_TITLE));
+    compare_fields!(errors, expected, actual, eq, subtitle_str);
+    compare_fields!(errors, expected, actual, eq, artist_str, is_default_str(DEFAULT_ARTIST));
+    compare_fields!(errors, expected, actual, eq, titletranslit_str);
+    compare_fields!(errors, expected, actual, eq, subtitletranslit_str);
+    compare_fields!(errors, expected, actual, eq, artisttranslit_str);
+    compare_fields!(errors, expected, actual, eq, display_bpm_str);
+    compare_fields!(errors, expected, actual, eq, credit_str);
+    compare_fields!(errors, expected, actual, eq, genre_str);
+    compare_fields!(errors, expected, actual, eq, lyrics_path);
+    compare_fields!(errors, expected, actual, eq, music_path);
+    compare_fields!(errors, expected, actual, eq, cdtitle_path);
+    compare_fields!(errors, expected, actual, eq, background_path);
+    compare_fields!(errors, expected, actual, eq, banner_path);
+
+    if exemptions.is_ssc {
+        compare_fields!(errors, expected, actual, version_eq, ssc_version, is_default_version(0.83));
+        compare_fields!(errors, expected, actual, eq, origin_str);
+        compare_fields!(errors, expected, actual, eq, discimage_path);
+        compare_fields!(errors, expected, actual, eq, cdimage_path);
+        compare_fields!(errors, expected, actual, eq, previewvid_path);
+        compare_fields!(errors, expected, actual, eq, jacket_path);
+    }
+
+    if errors.is_empty() {
+        Ok(())
     } else {
-        String::new()
-    };
-    let actual_ssc_version = if actual.ssc_version.is_finite() {
-        format!("{:.2}", actual.ssc_version)
-    } else {
-        String::new()
-    };
-
-    let mut comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
-        build_comparison_entry!(title_str, expected, actual, DEFAULT_TITLE),
-        build_comparison_entry!(subtitle_str, expected, actual),
-        build_comparison_entry!(artist_str, expected, actual, DEFAULT_ARTIST),
-        build_comparison_entry!(titletranslit_str, expected, actual),
-        build_comparison_entry!(subtitletranslit_str, expected, actual),
-        build_comparison_entry!(artisttranslit_str, expected, actual),
-        build_comparison_entry!(display_bpm_str, expected, actual),
-        build_comparison_entry!(credit_str, expected, actual),
-        build_comparison_entry!(genre_str, expected, actual),
-        build_comparison_entry!(lyrics_path, expected, actual),
-        build_comparison_entry!(music_path, expected, actual),
-        build_comparison_entry!(cdtitle_path, expected, actual),
-        build_comparison_entry!(background_path, expected, actual),
-        build_comparison_entry!(banner_path, expected, actual),
-    ];
-    if is_ssc {
-        comparison_table.extend_from_slice(&[
-            version_comparison_entry!(&expected_ssc_version, &actual_ssc_version, DEFAULT_VERSION),
-            build_comparison_entry!(origin_str, expected, actual),
-            build_comparison_entry!(discimage_path, expected, actual),
-            build_comparison_entry!(cdimage_path, expected, actual),
-            build_comparison_entry!(previewvid_path, expected, actual),
-            build_comparison_entry!(jacket_path, expected, actual),
-        ]);
+        Err(String::from("Simfile string field mismatches:\n") + &errors)
     }
-
-    let all_ok = comparison_table.iter().all(|entry| entry.3);
-
-    if all_ok {
-        return Ok(());
-    }
-
-    let mut error_details = String::new();
-    for (field_name, expected, actual, cmp, _) in comparison_table {
-        error_details += &format!(
-            "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
-            field_name,
-            expected,
-            actual,
-            match cmp {
-                true => "....ok",
-                false => "....MISMATCH",
-            }
-        );
-    }
-
-    Err(format!(
-        "\n\nMISMATCH DETECTED\nFile: {}\n{}",
-        path.display(),
-        error_details,
-    ))
 }
 
+#[rustfmt::skip]
 fn compare_simfile_normalized_fields(
-    path: &Path,
     expected: &SimfileSummary,
     actual: &SimfileSummary,
+    exemptions: &Exemptions,
 ) -> Result<(), String> {
-    let comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
-        build_normalized_comparison_entry!(normalized_bpms, expected, actual, NORM_DEFAULT_BPMS),
-        build_normalized_comparison_entry!(normalized_stops, expected, actual),
-        build_normalized_comparison_entry!(normalized_delays, expected, actual),
-        build_normalized_comparison_entry!(
-            normalized_speeds,
-            expected,
-            actual,
-            NORM_DEFAULT_SPEEDS
-        ),
-        build_normalized_comparison_entry!(
-            normalized_scrolls,
-            expected,
-            actual,
-            NORM_DEFAULT_SCROLLS
-        ),
-        build_normalized_comparison_entry!(normalized_fakes, expected, actual),
-        build_normalized_comparison_entry!(
-            normalized_time_signatures,
-            expected,
-            actual,
-            DEFAULT_TIME_SIGNATURES
-        ),
-        build_normalized_comparison_entry!(normalized_labels, expected, actual, DEFAULT_LABELS),
-        build_normalized_comparison_entry!(
-            normalized_tickcounts,
-            expected,
-            actual,
-            DEFAULT_TICKCOUNTS
-        ),
-        build_normalized_comparison_entry!(normalized_combos, expected, actual, DEFAULT_COMBOS),
-        build_normalized_comparison_entry!(normalized_bgchanges, expected, actual),
-        build_normalized_comparison_entry!(normalized_fgchanges, expected, actual),
-        build_normalized_comparison_entry!(normalized_keysounds, expected, actual),
-        build_normalized_comparison_entry!(normalized_attacks, expected, actual),
-    ];
+    let mut errors = String::new();
 
-    let all_ok = comparison_table.iter().all(|entry| entry.3);
-
-    if all_ok {
-        return Ok(());
+    if !exemptions.has_hash_breaking_bpms && !exemptions.has_warp_hacks {
+        compare_fields!(errors, expected, actual, normalized_eq, normalized_bpms, is_default_str(NORM_DEFAULT_BPMS));
     }
-
-    // Build error string
-    let mut error_details = String::from("Simfile normalized field mismatches:\n");
-    for (field_name, expected, actual, cmp, _) in comparison_table {
-        error_details += &format!(
-            "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
-            field_name,
-            expected,
-            actual,
-            match cmp {
-                true => "....ok",
-                false => "....MISMATCH",
-            }
-        );
+    if !exemptions.has_warp_hacks {
+        compare_fields!(errors, expected, actual, normalized_eq, normalized_stops);
+        compare_fields!(errors, expected, actual, normalized_eq, normalized_delays);
+        compare_fields!(errors, expected, actual, normalized_eq, normalized_warps);
     }
-
-    Err(format!(
-        "\n\nMISMATCH DETECTED\nFile: {}\n{}",
-        path.display(),
-        error_details,
-    ))
-}
-
-fn compare_chart_str_fields_and_hashes(
-    path: &Path,
-    expected_charts: &[ChartSummary],
-    actual_charts: &[ChartSummary],
-) -> Result<(), String> {
-    let mut errors: Vec<String> = Vec::new();
-
-    let count = expected_charts.len().max(actual_charts.len());
-    for idx in 0..count {
-        let expected_chart_opt = expected_charts.get(idx);
-        let actual_chart_opt = actual_charts.get(idx);
-
-        match (expected_chart_opt, actual_chart_opt) {
-            (None, None) => panic!(), // Unreachable
-            (None, Some(actual_chart)) => {
-                errors.push(format!(
-                    "Unexpected {} {} chart at index {}",
-                    actual_chart.step_type_str, actual_chart.difficulty_str, idx
-                ));
-            }
-            (Some(expected_chart), None) => {
-                errors.push(format!(
-                    "Expected {} {} chart at index {}",
-                    expected_chart.step_type_str, expected_chart.difficulty_str, idx
-                ));
-            }
-            (Some(expected_chart), Some(actual_chart)) => {
-                let expected_radar_values = format_radar_values(expected_chart.cached_radar_values);
-                let actual_radar_values = format_radar_values(actual_chart.cached_radar_values);
-                let comparison_table: Vec<(&str, &str, &str, bool, Option<&[u8]>)> = vec![
-                    build_comparison_entry!(
-                        step_type_str,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_STEPSTYPE
-                    ),
-                    build_comparison_entry!(step_artist_str, expected_chart, actual_chart),
-                    build_comparison_entry!(description_str, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_name_str, expected_chart, actual_chart),
-                    build_comparison_entry!(chart_style_str, expected_chart, actual_chart),
-                    build_comparison_entry!(
-                        difficulty_str,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_DIFFICULTY
-                    ),
-                    build_comparison_entry!(
-                        rating_str,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_METER
-                    ),
-                    build_comparison_entry!(short_hash, expected_chart, actual_chart),
-                    build_comparison_entry!(bpm_neutral_hash, expected_chart, actual_chart),
-                    (
-                        "cached_radar_values",
-                        &expected_radar_values,
-                        &actual_radar_values,
-                        compare_radar_values(
-                            expected_chart.cached_radar_values.as_ref(),
-                            actual_chart.cached_radar_values.as_ref(),
-                        ),
-                        None,
-                    ),
-                ];
-
-                let all_ok = comparison_table.iter().all(|entry| entry.3);
-
-                if all_ok {
-                    continue;
-                }
-
-                // Build error string
-                let mut error_details = String::new();
-                for (field_name, expected, actual, cmp, _) in comparison_table {
-                    error_details += &format!(
-                        "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
-                        field_name,
-                        expected,
-                        actual,
-                        match cmp {
-                            true => "....ok",
-                            false => "....MISMATCH",
-                        }
-                    );
-                }
-
-                errors.push(error_details);
-            }
-        }
-    }
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_speeds, is_default_str(NORM_DEFAULT_SPEEDS));
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_scrolls, is_default_str(NORM_DEFAULT_SCROLLS));
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_fakes);
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_time_signatures, is_default_str(DEFAULT_TIME_SIGNATURES));
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_labels, is_default_str(DEFAULT_LABELS));
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_tickcounts, is_default_str(DEFAULT_TICKCOUNTS));
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_combos, is_default_str(DEFAULT_COMBOS));
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_bgchanges);
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_fgchanges);
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_keysounds);
+    compare_fields!(errors, expected, actual, normalized_eq, normalized_attacks);
 
     if errors.is_empty() {
-        return Ok(());
+        Ok(())
+    } else {
+        Err(String::from("Simfile normalized field mismatches:\n") + &errors)
     }
-
-    let mut error_details = String::from("Chart timing field mismatches:\n");
-    for line in errors {
-        error_details.push_str(&line);
-        error_details.push('\n');
-    }
-
-    Err(format!(
-        "\n\nMISMATCH DETECTED\nFile: {}\n{}\n",
-        path.display(),
-        error_details
-    ))
 }
 
-fn compare_chart_timing_fields(
-    path: &Path,
-    expected_charts: &[ChartSummary],
-    actual_charts: &[ChartSummary],
+#[rustfmt::skip]
+fn compare_simfile_timing_fields(
+    expected: &SimfileSummary,
+    actual: &SimfileSummary,
+    exemptions: &Exemptions,
 ) -> Result<(), String> {
-    let mut errors: Vec<String> = Vec::new();
+    let mut errors = String::new();
+    let expected_timing = &expected.global_timing_segments;
+    let actual_timing = &actual.global_timing_segments;
 
-    let count = expected_charts.len().max(actual_charts.len());
-    for idx in 0..count {
-        let expected_chart_opt = expected_charts.get(idx);
-        let actual_chart_opt = actual_charts.get(idx);
-
-        match (expected_chart_opt, actual_chart_opt) {
-            (None, None) => panic!(), // Unreachable
-            (None, Some(actual_chart)) => {
-                errors.push(format!(
-                    "Unexpected {} {} chart at index {}",
-                    actual_chart.step_type_str, actual_chart.difficulty_str, idx
-                ));
-            }
-            (Some(expected_chart), None) => {
-                errors.push(format!(
-                    "Expected {} {} chart at index {}",
-                    expected_chart.step_type_str, expected_chart.difficulty_str, idx
-                ));
-            }
-            (Some(expected_chart), Some(actual_chart)) => {
-                // Massage this boolean into a string to keep the comparison table simple
-                let expected_chart_has_own_timing = expected_chart.chart_has_own_timing.to_string();
-                let actual_chart_has_own_timing = actual_chart.chart_has_own_timing.to_string();
-
-                let comparison_table: Vec<(&str, &String, &String, bool, Option<&[u8]>)> = vec![
-                    // Compare these again here for important debugging context
-                    build_comparison_entry!(step_type_str, expected_chart, actual_chart),
-                    build_comparison_entry!(difficulty_str, expected_chart, actual_chart),
-                    build_comparison_entry!(rating_str, expected_chart, actual_chart),
-                    // Compare these again here to log timing data when hash breaks
-                    build_comparison_entry!(short_hash, expected_chart, actual_chart),
-                    build_comparison_entry!(bpm_neutral_hash, expected_chart, actual_chart),
-                    (
-                        "chart_has_own_timing",
-                        &expected_chart_has_own_timing,
-                        &actual_chart_has_own_timing,
-                        expected_chart.chart_has_own_timing == actual_chart.chart_has_own_timing,
-                        None,
-                    ),
-                    build_comparison_entry_opt!(chart_attacks, expected_chart, actual_chart),
-                    build_comparison_entry_opt!(chart_stops, expected_chart, actual_chart),
-                    build_comparison_entry_opt!(
-                        chart_speeds,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_SPEEDS
-                    ),
-                    build_comparison_entry_opt!(
-                        chart_scrolls,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_SCROLLS
-                    ),
-                    build_comparison_entry_opt!(
-                        chart_bpms,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_BPMS
-                    ),
-                    build_comparison_entry_opt!(chart_delays, expected_chart, actual_chart),
-                    build_comparison_entry_opt!(chart_warps, expected_chart, actual_chart),
-                    build_comparison_entry_opt!(chart_fakes, expected_chart, actual_chart),
-                    build_comparison_entry_opt!(chart_display_bpm, expected_chart, actual_chart),
-                    build_comparison_entry_opt!(
-                        chart_time_signatures,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_TIME_SIGNATURES
-                    ),
-                    build_comparison_entry_opt!(
-                        chart_labels,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_LABELS
-                    ),
-                    build_comparison_entry_opt!(
-                        chart_tickcounts,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_TICKCOUNTS
-                    ),
-                    build_comparison_entry_opt!(
-                        chart_combos,
-                        expected_chart,
-                        actual_chart,
-                        DEFAULT_COMBOS
-                    ),
-                ];
-
-                let all_ok = comparison_table.iter().all(|entry| entry.3);
-
-                if all_ok {
-                    continue;
-                }
-
-                // Build error string
-                let mut error_details = String::from("Chart timing field mismatches:\n");
-                for (field_name, expected, actual, cmp, _) in comparison_table {
-                    error_details += &format!(
-                        "  {}: baseline: {:?} -> reencoded: {:?} {}\n",
-                        field_name,
-                        expected,
-                        actual,
-                        match cmp {
-                            true => "....ok",
-                            false => "....MISMATCH",
-                        }
-                    );
-                }
-
-                errors.push(error_details);
-            }
-        }
+    if !exemptions.has_warp_hacks {
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, bpms, is_default_pairs(TIMING_DEFAULT_BPMS));
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, stops);
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, delays);
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, warps);
     }
+    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, scrolls, is_default_pairs(TIMING_DEFAULT_SCROLLS));
+    compare_fields!(errors, expected_timing, actual_timing, timing_speeds_eq, speeds, is_default_speeds(TIMING_DEFAULT_SPEEDS));
+    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, fakes);
 
     if errors.is_empty() {
-        return Ok(());
+        Ok(())
+    } else {
+        Err(String::from("Simfile timing mismatches:\n") + &errors)
     }
-
-    let mut error_details = String::new();
-    for line in errors {
-        error_details.push_str(&line);
-        error_details.push('\n');
-    }
-
-    Err(format!(
-        "\n\nMISMATCH DETECTED\nFile: {}\n{}\n",
-        path.display(),
-        error_details
-    ))
 }
 
-fn compare_timing(
-    path: &Path,
+#[rustfmt::skip]
+fn compare_chart_str_fields(
+    expected: &ChartSummary,
+    actual: &ChartSummary,
+    _exemptions: &Exemptions,
+) -> Result<(), String> {
+    let mut errors = String::new();
+
+    compare_fields!(errors, expected, actual, eq, step_type_str, is_default_str(DEFAULT_STEPSTYPE));
+    compare_fields!(errors, expected, actual, eq, step_artist_str);
+    compare_fields!(errors, expected, actual, eq, description_str);
+    compare_fields!(errors, expected, actual, eq, chart_name_str);
+    compare_fields!(errors, expected, actual, eq, chart_style_str);
+    compare_fields!(errors, expected, actual, eq, difficulty_str, is_default_str(DEFAULT_DIFFICULTY));
+    compare_fields!(errors, expected, actual, eq, rating_str, is_default_str(DEFAULT_METER));
+    compare_fields!(errors, expected, actual, radar_values_eq, cached_radar_values);
+    compare_fields!(errors, expected, actual, eq, chart_display_bpm);
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(String::from("Chart string field mismatches:\n") + &errors)
+    }
+}
+
+#[rustfmt::skip]
+fn compare_chart_hashes_and_timing(
+    expected: &ChartSummary,
+    actual: &ChartSummary,
+    exemptions: &Exemptions,
+) -> Result<(), String> {
+    let mut errors = String::new();
+    let expected_timing = &expected.timing_segments;
+    let actual_timing = &actual.timing_segments;
+
+    if !exemptions.has_hash_breaking_bpms && !exemptions.has_warp_hacks {
+        compare_fields!(errors, expected, actual, eq, short_hash);
+    }
+    compare_fields!(errors, expected, actual, eq, bpm_neutral_hash);
+    compare_fields!(errors, expected, actual, eq, chart_has_own_timing);
+    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_time_signatures, is_default_bytes_opt(DEFAULT_TIME_SIGNATURES));
+    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_labels, is_default_bytes_opt(DEFAULT_LABELS));
+    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_tickcounts, is_default_bytes_opt(DEFAULT_TICKCOUNTS));
+    compare_fields!(errors, expected, actual, normalized_opt_eq, chart_combos, is_default_bytes_opt(DEFAULT_COMBOS));
+    if !exemptions.has_warp_hacks {
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, bpms, is_default_pairs(&[(0.0f32, 60.0f32)]));
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, stops);
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, delays);
+        compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, warps);
+    }
+    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, scrolls, is_default_pairs(&[(0.0f32, 1.0f32)]));
+    compare_fields!(errors, expected_timing, actual_timing, timing_speeds_eq, speeds, is_default_speeds(&[(0.0f32, 1.0f32, 0.0f32, SpeedUnit::Beats)]));
+    compare_fields!(errors, expected_timing, actual_timing, timing_pairs_eq, fakes);
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(String::from("Chart hash / timing mismatches:\n") + &errors)
+    }
+}
+
+fn compare_charts(
     expected_simfile: &SimfileSummary,
     actual_simfile: &SimfileSummary,
+    exemptions: &Exemptions,
 ) -> Result<(), String> {
-    let mut errors: Vec<String> = Vec::new();
+    let mut errors = String::new();
 
     let count = expected_simfile
         .charts
@@ -651,67 +382,35 @@ fn compare_timing(
         match (expected_chart_opt, actual_chart_opt) {
             (None, None) => panic!(), // Unreachable
             (None, Some(actual_chart)) => {
-                errors.push(format!(
-                    "Unexpected {} {} chart at index {}",
+                errors += &format!(
+                    "Unexpected {} {} chart at index {}\n",
                     actual_chart.step_type_str, actual_chart.difficulty_str, idx
-                ));
+                );
             }
             (Some(expected_chart), None) => {
-                errors.push(format!(
-                    "Expected {} {} chart at index {}",
+                errors += &format!(
+                    "Expected {} {} chart at index {}\n",
                     expected_chart.step_type_str, expected_chart.difficulty_str, idx
-                ));
+                );
             }
             (Some(expected_chart), Some(actual_chart)) => {
-                let expected_timing = build_timing_snapshot(expected_chart, expected_simfile);
-                let actual_timing = build_timing_snapshot(actual_chart, actual_simfile);
-                let timing_comparison_table =
-                    build_timing_comparison_table(&expected_timing, &actual_timing);
-
-                let all_ok = timing_comparison_table.iter().all(|entry| entry.1);
-
-                if all_ok {
-                    continue;
+                match compare_chart_str_fields(expected_chart, actual_chart, exemptions) {
+                    Err(errs) => errors += &errs,
+                    _ => {}
                 }
-
-                // Build error string
-                let mut error_details = String::from("Chart timing data mismatches:\n");
-                for (field_name, matches) in timing_comparison_table {
-                    error_details += &format!(
-                        "  {}: {}\n",
-                        field_name,
-                        match matches {
-                            true => "....ok",
-                            false => "....MISMATCH",
-                        }
-                    );
+                match compare_chart_hashes_and_timing(expected_chart, actual_chart, exemptions) {
+                    Err(errs) => errors += &errs,
+                    _ => {}
                 }
-
-                error_details += &format!(
-                    "\nExpected: {:?}\nActual: {:?}\n",
-                    expected_timing, actual_timing
-                );
-
-                errors.push(error_details);
             }
         }
     }
 
     if errors.is_empty() {
-        return Ok(());
+        Ok(())
+    } else {
+        Err(errors)
     }
-
-    let mut error_details = String::from("Timing mismatches:\n");
-    for line in errors {
-        error_details.push_str(&line);
-        error_details.push('\n');
-    }
-
-    Err(format!(
-        "\n\nMISMATCH DETECTED\nFile: {}\n{}\n",
-        path.display(),
-        error_details
-    ))
 }
 
 fn run_rssp_analyze(raw_bytes: &[u8], extension: &str) -> Result<SimfileSummary, String> {
@@ -728,13 +427,14 @@ fn run_rssp_analyze(raw_bytes: &[u8], extension: &str) -> Result<SimfileSummary,
 }
 
 fn check_file(path: &Path, extension: &str) -> Result<(), String> {
-    let ssc = extension_is_ssc(extension).map_err(|e| e.to_string())?;
+    let is_ssc = extension_is_ssc(extension).map_err(|e| e.to_string())?;
     let compressed_bytes = fs::read(path).map_err(|e| format!("Failed to read file: {e}"))?;
 
     let raw_bytes = zstd::decode_all(&compressed_bytes[..])
         .map_err(|e| format!("Failed to decompress simfile: {e}"))?;
 
     let base_summary = run_rssp_analyze(&raw_bytes, extension)?;
+    let exemptions = Exemptions::for_simfile(&base_summary, is_ssc);
 
     // Serialize to simfile bytes in memory
     let mut buffer = vec![];
@@ -748,22 +448,50 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
 
     println!("File: {}", path.display());
 
-    compare_simfile_str_fields(path, extension, &base_summary, &reencoded_summary)?;
-    compare_simfile_normalized_fields(path, &base_summary, &reencoded_summary)?;
+    let mut comparison_results = Vec::with_capacity(6); // should match # of tests below
+
+    comparison_results.push(compare_simfile_str_fields(
+        &base_summary,
+        &reencoded_summary,
+        &exemptions,
+    ));
+    comparison_results.push(compare_simfile_normalized_fields(
+        &base_summary,
+        &reencoded_summary,
+        &exemptions,
+    ));
+    comparison_results.push(compare_simfile_timing_fields(
+        &base_summary,
+        &reencoded_summary,
+        &exemptions,
+    ));
 
     // A few SSC files in the corpus are missing a #VERSION tag
     // but have per-chart timing data, which is invalid.
     // Don't bother validating these.
-    if ssc && !base_summary.ssc_version.is_finite() {
-        println!("SSC file is missing a version - skipping chart & timing tests");
-        return Ok(());
-    };
+    if is_ssc && !base_summary.ssc_version.is_finite() {
+        println!("SSC file is missing a version - skipping chart tests");
+    } else {
+        comparison_results.push(compare_charts(
+            &base_summary,
+            &reencoded_summary,
+            &exemptions,
+        ));
+    }
 
-    compare_chart_timing_fields(path, &base_summary.charts, &reencoded_summary.charts)?;
-    compare_chart_str_fields_and_hashes(path, &base_summary.charts, &reencoded_summary.charts)?;
-    compare_timing(path, &base_summary, &reencoded_summary)?;
-
-    Ok(())
+    let all_ok = comparison_results.iter().all(|r| r.is_ok());
+    if all_ok {
+        Ok(())
+    } else {
+        let mut err = "\n\nMISMATCH DETECTED\n".to_string();
+        for result in comparison_results {
+            match result {
+                Err(e) => err.push_str(&e),
+                Ok(_) => {}
+            }
+        }
+        Err(err)
+    }
 }
 
 fn main() {
@@ -879,7 +607,7 @@ fn main() {
             Err(msg) => {
                 println!("test {name} ... FAILED");
                 failures.push(Failure {
-                    name,
+                    name: path.to_string_lossy().to_string(),
                     message: msg.trim().to_string(),
                 });
                 num_failed += 1;

--- a/crates/rssp/tests/serialize_parity.rs
+++ b/crates/rssp/tests/serialize_parity.rs
@@ -702,14 +702,12 @@ fn check_file(path: &Path, extension: &str) -> Result<(), String> {
         serialize_simfile(&base_summary, extension, &mut cursor).map_err(|e| e.to_string())?;
     };
 
-    //print!("{}", String::from_utf8(buffer.clone()).unwrap());
-
     // Re-run rssp analyze on the serialized simfile
     let reencoded_summary = run_rssp_analyze(&buffer, extension)?;
 
     println!("File: {}", path.display());
 
-    let mut comparison_results = Vec::with_capacity(6); // should match # of tests below
+    let mut comparison_results = Vec::with_capacity(4); // should match # of tests below
 
     comparison_results.push(compare_simfile_str_fields(
         &base_summary,


### PR DESCRIPTION
PR 4 of 4 for serialization.

In terms of rssp's public API, this PR adds two functions:

* **`rssp::serialize::serialize_simfile`**: write the contents of a `&SimfileSummary` in either the `.sm` or `.ssc` format.
  * Timing data is stored duplicitously at multiple levels: `normalized_*` fields and `global_timing_segments` on the `SimfileSummary`, as well as `chart_*` fields and `timing_segments` on the `ChartSummary`. **The parsed timing segments are preferred in all cases.**
  * Chart timing fields are only written if `chart_has_own_timing` is true. This is reflective of the canonical behavior.
  * Chart attacks are only written if `chart_has_own_attacks` is true. This is _not_ reflective of the canonical behavior, but prevents duplicating global attacks during serialization; see #13 for details.
  * `NOTES2` is not yet implemented. No file in the corpus uses this field, and I'm only aware of a single pad file that uses it ("L9" from the UPS pack). It shouldn't be hard to implement, it's just low-priority.

* **`rssp_core::timing::convert_warps_and_delays_to_sm_stops`**: reverse the `.sm` warp hack conversion done during parsing so that the original timing data can be restored.
  * This is lossy if a negative BPM and a stop/delay coincide, as they can't both be represented by a stop on the same tick. In the future, this could be avoided by reconstructing such warps as negative BPMs, but I regarded this as out-of-scope since StepMania / ITGmania don't do this either.
  * It's also lossy if a stop and a delay coincide with each other, and there's no way around this to my knowledge. So this function can't be made bulletproof either way - `.sm` is simply lacking capabilities that SSC has.

The serializer parity test ensures that the parsed summary remains the same after serializing and re-parsing, with a few exemptions for known edge cases. These cases are documented in the comments and largely revolve around floating point imprecision and legacy `.sm` hacks.