### PR TITLE
Add support for `wasm32-*` targets

### DIFF
--- a/crates/rssp/Cargo.toml
+++ b/crates/rssp/Cargo.toml
@@ -13,6 +13,9 @@ memchr = "2.8.3"
 rssp-core = { workspace = true }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = { version = "1.1.0", features = ["serde"] }
+
 [features]
 profile = ["rssp-core/bench-support"]
 

--- a/crates/rssp/src/analysis.rs
+++ b/crates/rssp/src/analysis.rs
@@ -1,6 +1,9 @@
 use std::borrow::Cow;
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::duration::{self, TimingOffsets};
 use crate::report::{ChartSummary, SimfileSummary};

--- a/crates/rssp/src/course.rs
+++ b/crates/rssp/src/course.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
+#[cfg(target_arch = "wasm32")]
+use web_time::{Duration, Instant};
 
 use crate::analysis::AnalysisOptions;
 use crate::assets;

--- a/crates/rssp/src/report.rs
+++ b/crates/rssp/src/report.rs
@@ -1,6 +1,9 @@
 use std::io::{self, Write};
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
+#[cfg(target_arch = "wasm32")]
+use web_time::Duration;
 
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
 

--- a/crates/rssp/src/report.rs
+++ b/crates/rssp/src/report.rs
@@ -191,7 +191,7 @@ const fn compute_simple_quad_parts(
 }
 
 // Make the struct and its fields public
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChartSummary {
     pub step_type_str: String,
     pub step_artist_str: String,
@@ -264,7 +264,7 @@ pub struct ChartSummary {
 }
 
 // Make the struct and its fields public
-#[derive(Debug)] // Add Debug for easier use in the engine
+#[derive(Debug, Clone)] // Add Debug for easier use in the engine
 pub struct SimfileSummary {
     pub title_str: String,
     pub subtitle_str: String,


### PR DESCRIPTION
Two changes here:

* Derive `Clone` on `SimfileSummary` and `ChartSummary`. This is required for structs pulled in via `#[wasm_bindgen]`.
* After initially exploring a `no_time` feature flag to disable uses of `Duration` and `Instant`, I opted to instead conditionally pull in the [web-time](https://crates.io/crates/web-time) crate, which serves as a drop-in replacement for `std::time`. This keeps the change very compact & doesn't degrade rssp's platform-independent capabilities.

